### PR TITLE
Fixes YouTube Feed #45

### DIFF
--- a/public/feed/youtube.php
+++ b/public/feed/youtube.php
@@ -5,20 +5,30 @@ include_once('json_common.php');
 /*
  * Echo out the data
  */
- 
-// FIXME - Playlists probably aren't the best thing to feed to our page.
-// Consider uploads instead (once we have some).
-$playlist_id = 'PLQ3DxyvaP9n270bhIYnif5jnTlZSdml3G';
-$obj = get_json_data('youtube', 'playlistItems', '&playlistId=' . $playlist_id . '&part=snippet&maxResults=25');
+
+$videos_url = 'https://www.youtube.com/user/LMMSOfficial/videos';
+$obj = get_json_data('youtube', 'activities', '&part=snippet&maxResults=25');
 
 echo '<table class="table table-striped"><th><h2 class="center">LMMS YouTube</h2></th>';
 foreach ($obj as $items) {
 	if (!is_array($items) || count($items) < 1 ) {
 		continue;
 	}
+	
+	$duplicates = array();
 
 	foreach($items as $item) {
 		$item = $item->snippet;
+		
+		// YouTube seems to have some duplicates in their feed (likely historical edits)
+		// This is a quick hack to check for duplicates based on title name
+		if (array_key_exists($item->title, $duplicates)) {
+			continue;
+		}
+
+		$duplicates[$item->title] = true;
+
+
 		$id = parse_youtube_id($item->thumbnails->default->url);
 		$url = $id ? 'http://www.youtube.com/watch?v=' . $id : '';
 		
@@ -28,7 +38,7 @@ foreach ($obj as $items) {
 			"javascript:embedVideo('#div-" . $id . "','" . $id . "')", 						// $href	i.e. "http://facebook.com/post1234"
 			trim_feed($item->description, $url),	// $message   i.e "We are pleased to announce..." 
 			$item->channelTitle, 		// $author	i.e. "John Smith"
-			'https://www.youtube.com/playlist?list=' . $playlist_id, 			// $author_href	i.e. "http://facebook.com/user1234"
+			$videos_url, 				// $author_href	i.e. "http://facebook.com/user1234"
 			$item->publishedAt,			// $date	i.e. "2014-01-01 00:00:00"
 			$item->thumbnails->default->url,
 			'div-' . $id


### PR DESCRIPTION
Pulls from the "activities" feed instead of the empty "playlist" feed.  Should probably be tweaked to just return videos, but its better than erroring out.
