### PR TITLE
OS Selection Text

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -46,7 +46,7 @@ include_once('utils.php');
 		<a href="/download/#linux" class="btn btn-default"><span class="fa-5x fa fa-linux fa-fw"></span></a>&nbsp;
 		<a href="/download/#windows" class="btn btn-default"><span class="fa-5x fa fa-windows fa-fw"></span></a>&nbsp;
 		<a href="/download/#mac" class="btn btn-default"><span class="fa-5x fa fa-apple fa-fw"></span></a>&nbsp;
-		<h4>Take a pick</h4>
+		<h4>Take your pick</h4>
 		<p>for Linux, Windows or Apple OS X</p>
 	</div>
 </div>


### PR DESCRIPTION
Changed "Take a pick" to the more commonly used "Take your pick". Ironically, this is quite the nitpick.
