### PR TITLE
Download page: Don't scroll to selected tab

### DIFF
--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -91,11 +91,11 @@
 function showOS(os) {
 	location.hash = os;
 	if (os.indexOf("linux") != -1) {
-		if (os != "#linux") {
-			$(os+"-button").tab("show");
-		} else {
-			$("#linux-debian-button").tab("show");
+		if (os == "#linux") {
+			// Default linux distro shown is Debian
+			os = "#linux-debian";
 		}
+		$(os+"-button").tab("show");
 		os = "#linux";
 		$('#prerelease').hide();
 	} else {
@@ -161,7 +161,6 @@ $(function() {
 });
 
 $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-	location.hash = e.target.hash;
 	$(e.target).parent().children().removeClass("active");
 	e.target.classList.add("active");
 })


### PR DESCRIPTION
This fixes #133. It prevents auto-scrolling when (auto-)selecting an OS/distro tab. 

However, this is done by not writing a tab select into `location.hash`, so when clicking a distro tab, the selected tab will not occur in the URL but just keep saying `/download/#linux`.
Linking to directly to a distro (e.g. 'https://lmms.io/download/#linux-debian`) will still work.