### PR TITLE
Make server path to serve from more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ This repo contains the source for LMMS's new website located at http://lmms.io.
 	
 1. Start local server
 
-	Start a local PHP server by running from lmms.io/public:
-	
 	```bash
-	$ php -S localhost:8000 -t ./
+	$ php -S localhost:8000 -t ./public/
 	```
 	
 	You can then open http://localhost:8000/ in a browser.


### PR DESCRIPTION
A minuscule change, but when setting this up locally, I skimmed over the instructions and missed the part where it said to run it from `lmms.io/public`. This change makes it more visible so it's not as easily missed.

What do you think?