### PR TITLE
Add GitHub webhook endpoint to send events to Discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *~
+.idea
+*.sublime-project
+*.sublime-workspace
 /public/community/cache/
 /public/feed/cache/
 /public/cache/
@@ -6,3 +9,4 @@
 /tmp/
 /vendor/
 composer.phar
+

--- a/hooks/github.php
+++ b/hooks/github.php
@@ -1,0 +1,68 @@
+<?php
+
+require_once('../lib/Discord.php');
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use LMMS\Discord;
+
+
+function checkGithubSignature($content, $signature) {
+	$parts = explode('=', $signature, 2);
+	$hashAlgo = $parts[0];
+	$hash = $parts[1];
+	if (!in_array($hashAlgo, hash_algos())) {
+		error_log("Unknown hash algorithm: {$hashAlgo}");
+		return false;
+	}
+	$computedHash = hash_hmac($hashAlgo, $content, GITHUB_HOOK_SECRET);
+	if ($computedHash !== $hash) {
+		error_log("Signature mismatch: Expected {$computedHash}, got {$hash}");
+		return false;
+	}
+	return true;
+}
+
+
+function githubHook(Request $request) {
+
+	// Make sure this actually comes from GitHub
+	$content = $request->getContent();
+	$signature = $request->headers->get('x-hub-signature');
+	if (!checkGithubSignature($content, $signature)) {
+		return new Response("Bad signature", Response::HTTP_UNPROCESSABLE_ENTITY);
+	}
+
+	$hookData = json_decode($content);
+	$repo = $hookData->repository->name;
+	$prefix = "[**{$repo}**]";
+	$importantActions = ['opened', 'closed', 'reopened'];
+	$action = $hookData->action;
+
+	if (property_exists($hookData, 'issue')) {
+		$issue = $hookData->issue;
+		$url = $issue->html_url;
+		$user = $issue->user->login;
+
+		if (in_array($action, $importantActions)) {
+			Discord\sendMessage("{$prefix} {$user} {$action} issue: {$url}");
+		}
+	}
+	else if (property_exists($hookData, 'pull_request')) {
+		$pr = $hookData->pull_request;
+		$url = $pr->html_url;
+		$user = $pr->user->login;
+		
+		if (in_array($action, $importantActions)) {
+			if ($action === 'closed' && $pr->merged) {
+				$user = $pr->merged_by->login;
+				$action = 'merged';
+			}
+		
+			Discord\sendMessage("{$prefix} {$user} {$action} PR: {$url}");
+		}
+	}
+
+	return new Response("", Response::HTTP_OK);
+}

--- a/lib/Discord.php
+++ b/lib/Discord.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LMMS\Discord;
+
+
+function sendMessage($message) {
+	$client = new \GuzzleHttp\Client();
+	$url = "https://discordapp.com/api/channels/" . DISCORD_CHANNEL . "/messages";
+
+	$res = $client->post($url, [
+		'headers' => [
+			'Authorization' => "Bot " . DISCORD_TOKEN,
+			'User-Agent' => 'lmms.io GitHub/Discord Integration Bot (https://lmms.io/, 0.0.1)',
+		],
+		'json' => [
+			'content' => $message,
+		],
+	]);
+
+	if ($res->getStatusCode() !== 200) {
+		error_log("Failed to send message to discord: HTTP Status {$res->getStatusCode()}: {$res->getBody()}");
+	}
+}

--- a/public/app.php
+++ b/public/app.php
@@ -1,11 +1,12 @@
 <?php
 require_once($_SERVER['DOCUMENT_ROOT'].'/../vendor/autoload.php');
+require_once('config.php');
 require_once('navbar.php');
 
 $app = new Silex\Application();
 $app->register(new Silex\Provider\TwigServiceProvider(), array(
 	'twig.path' => __DIR__.'/../templates',
-	));
+));
 
 $app['twig']->addGlobal('navbar', $navbar);
 

--- a/public/config.php
+++ b/public/config.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * By default, the LSP will use the default database values defined in dbo.php.
+ * however, for production environments, the defaults must be overridden.  This
+ * is done in a separate config file which should be out of the document root
+ * and inaccessible from a webpage.
+ */
+$secretsFile = getenv('LSP_SECRETS') ?: '/home/deploy/secrets/LSP_SECRETS';
+
+if (!file_exists($secretsFile)) {
+	error_log("Secrets file does not exist: {$secretsFile}");
+}
+else if (!is_readable($secretsFile)) {
+	error_log('Secrets file is not readable: {$secretsFile}');
+}
+else {
+	include($secretsFile);
+}

--- a/public/index.php
+++ b/public/index.php
@@ -12,6 +12,7 @@ function twigrender($file)
 }
 
 require_once('../views.php');
+require_once('../hooks/github.php');
 
 $pages = [
 	['/', 'homePage'],
@@ -36,7 +37,10 @@ foreach ($pages as $page) {
 	$app->get($page[0], $page[1]);
 }
 
+$app->post('/hooks/github/', 'githubHook');
+
 $app->error(function (\Exception $e, $code) use($app) {
+	error_log($e);
 	switch ($code) {
 		case 404:
 			$message = 'The requested page could not be found.';

--- a/public/lsp/dbo.php
+++ b/public/lsp/dbo.php
@@ -1,14 +1,15 @@
 <?php
 require_once('utils.php');
+require_once('../config.php');
 
 /*
- * Default database values.  Override with LSP_SECRETS below
+ * Default database values.  Define in LSP_SECRETS file to override default values.
  */
-$DB_TYPE = 'mysql';
-$DB_HOST = 'localhost';
-$DB_USER = 'someuser';
-$DB_PASS = 'P@SSWORD';
-$DB_DATABASE = 'somedatabase';
+$DB_TYPE = defined('DB_TYPE') ? DB_TYPE : 'mysql';
+$DB_HOST = defined('DB_HOST') ? DB_HOST : 'localhost';
+$DB_USER = defined('DB_USER') ? DB_USER : 'someuser';
+$DB_PASS = defined('DB_PASS') ? DB_PASS : 'P@SSWORD';
+$DB_DATABASE = defined('DB_DATABASE') ? DB_DATABASE : 'somedatabase';
 
 /*
  * Query preferences
@@ -21,30 +22,9 @@ $MAX_LOGIN_ATTEMPTS = 6;
 /*
  * Global paths
  */
-$TMP_DIR = $_SERVER['DOCUMENT_ROOT'] . '/../tmp/';
-$DATA_DIR = $_SERVER['DOCUMENT_ROOT'] . '/../tmp/';
-$LSP_URL = '/lsp/';
-
-/*
- * By default, the LSP will use the default database values defined above
- * however, for production environments, the defaults must be overridden.  This
- * is done in a separate config file defined as $LSP_CONFIG which should be out
- * of the document root and inaccessible from a webpage.
- */
-$LSP_SECRET = '/home/deploy/secrets/LSP_SECRETS';
-if (file_exists($LSP_SECRET)) { include($LSP_SECRET); }
-
-/*
- * Override constants with those from $LSP_SECRET, if available
- */
-$DB_TYPE = defined('DB_TYPE') ? DB_TYPE : $DB_TYPE;
-$DB_HOST = defined('DB_HOST') ? DB_HOST : $DB_HOST;
-$DB_USER = defined('DB_USER') ? DB_USER : $DB_USER;
-$DB_PASS = defined('DB_PASS') ? DB_PASS : $DB_PASS;
-$DB_DATABASE = defined('DB_DATABASE') ? DB_DATABASE : $DB_DATABASE;
-$TMP_DIR = defined('TMP_DIR') ? TMP_DIR : $TMP_DIR;
-$DATA_DIR = defined('DB_PASS') ? DATA_DIR : $DATA_DIR;
-$LSP_URL = defined('LSP_URL') ? LSP_URL : $LSP_URL;
+$TMP_DIR = defined('TMP_DIR') ? TMP_DIR : $_SERVER['DOCUMENT_ROOT'] . '/../tmp/';
+$DATA_DIR = defined('DATA_DIR') ? DATA_DIR : $_SERVER['DOCUMENT_ROOT'] . '/../tmp/';
+$LSP_URL = defined('LSP_URL') ? LSP_URL : '/lsp/';
 
 /*
  * DANGER! When set to true will attempt to echo database statements and values to screen


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/199071/19024775/5b8e0486-88c0-11e6-884b-80200a4f2ea0.png)
## Setup
- Create a discord app: https://discordapp.com/developers/applications/me/create
- Define its bot token as `DISCORD_TOKEN` in `LSP_SECRETS`
- Set the discord channel to send events to by defining a `DISCORD_CHANNEL` in `LSP_SECRETS` and setting it to that channel's ID. You can get the channel ID from the URL when looking at a channel:
  ![image](https://cloud.githubusercontent.com/assets/199071/19024798/14945e1c-88c1-11e6-9bcc-4b9494be0243.png)
- Give it access to the LMMS discord server by going to `https://discordapp.com/oauth2/authorize?client_id=<client_id>&scope=bot`
- Add GitHub Webhooks pointing to https://lmms.io/hooks/github/ to e.g. the LMMS and lmms.io repositories. Use a hard-to-guess secret and define it as `GITHUB_HOOK_SECRET` in `LSP_SECRETS`
