### PR TITLE
Add email address on competitions page

### DIFF
--- a/templates/competitions.twig
+++ b/templates/competitions.twig
@@ -51,7 +51,7 @@
 			</li>
 			<li><b>The Judges</b>
 				<ul>
-				<li>The jury consists of: Greippi, Jacoby Davis, Spekular, Stakeout Punch and Squatro.</li>
+				<li>The jury consists of: Greippi, Jacoby Davis, Spekular (spekularr@gmail.com), Stakeout Punch and Squatro.</li>
 				</ul>
 			</li>
 			<li><b>The Judging Process</b>


### PR DESCRIPTION
I've ended up doing most of the communication with submitters when there are problems (broken links, invalid entries, etc.). Right now I'm asking for project files from some artists to confirm that their submissions are made with LMMS. Listing my email on the competitions page should lend me some credibility so submitters don't think I'm trying to steal their project files.