### PR TITLE
Update Discord link to point to #rules

### DIFF
--- a/templates/get-involved.twig
+++ b/templates/get-involved.twig
@@ -103,7 +103,7 @@
 				<a href="https://freenode.net/irc_servers.shtml">Freenode</a></p>
 				<p><a href="https://discordapp.com/" target="_blank">Discord</a>
 				is a more modern alternative to IRC. Join our server 
-				<a href="https://discord.gg/PHcQDx3">by clicking here</a></p>
+				<a href="https://discord.gg/3sc5su7">by clicking here</a></p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
We shuffled the channels around a bit and #welcome got deleted. #rules is what we want to link to now.