### PR TITLE
responsive documentation page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -878,3 +878,10 @@ ul.nav-center li {
 	margin-bottom: 1ex;
 	margin-top: 2ex;
 }
+
+/* responsive /documentation page */
+@media (max-width: 767px) {
+	#documentionTable, #documentionTable p {text-align: center;}
+	#documentionTable table td , #documentionTable div {width: 100%; min-width: 100%;}
+	#documentionTable table tr td {position: relative; float: left; width: 100%;}
+}

--- a/templates/documentation.twig
+++ b/templates/documentation.twig
@@ -1,7 +1,8 @@
 {% extends 'base.twig' %}
 
 {% block content %}
+<div id="documentionTable"> 
 <h1> {{ json.displaytitle }}</h1>
-
 {{ text|raw }}
+</div>
 {% endblock %}


### PR DESCRIPTION
Added a media query targeting 767px and below. 
Via this update the table data presented on the documentation page is assigned properties consistent with Bootstrap 3's column and row classes.
