### PR TITLE
Add Linux downloads

### DIFF
--- a/lib/Releases.php
+++ b/lib/Releases.php
@@ -61,11 +61,16 @@ class Releases
 		return $this->latestAssets('/.*\.dmg/', $stable);
 	}
 
+	public function latestLinuxAssets($stable = true)
+	{
+		return $this->latestAssets('/.*\.AppImage/', $stable);
+	}
+
 	/*
 	 * Get "32-bit", "64-bit", etc based on Download URL
 	 */
 	private function get_arch($text) {
-		$arch64 = array('amd64', 'win64', 'x86-64', 'x64', '64-bit', '.dmg');
+		$arch64 = array('amd64', 'win64', 'x86-64', 'x86_64', 'x64', '64-bit', '.dmg');
 		foreach ($arch64 as $x) {
 			if (strpos(strtolower($text), $x) !== false) {
 				return '64-bit';
@@ -99,6 +104,8 @@ class Releases
 			return 'macOS ' . $this->get_osver($text) . '+';
 		} else if (strpos($text, '.exe') !== false) {
 			return 'Windows ' . $this->get_arch($text);
+		} else if (strpos($text, '.AppImage') !== false) {
+			return 'Linux ' . $this->get_arch($text);
 		} else {
 			return $text;
 		}

--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -48,7 +48,30 @@
 </div>
 
 <div id="linux-div" class="text-center hidden">
-	{% include 'download/linux.twig' %}
+	<h2>Install LMMS on Linux</h2>
+	<p>Click one of the buttons below to download LMMS for Linux.</p>
+	{% if linstable %}
+		<h3>Stable Versions</h3>
+		{% for lin in linstable %}
+			{{ download.printrelbutton(lin) }}
+		{% endfor %}
+		{{ download.releasenotes(linstable[0]['release']['body'], 'linstable') }}
+		<p>Run <code>chmod +x ~/Downloads/*.AppImage</code> to set the <code>.AppImage</code> executable before running</p>
+	{% endif %}
+
+	{% if linpre %}
+		<h3>Beta Versions</h3>
+		{% for lin in linpre %}
+			{{ download.printrelbutton(lin, 'btn-warning') }}
+		{% endfor %}
+
+		{{ download.releasenotes(linpre[0]['release']['body'], 'linpre') }}
+	{% endif %}
+	<a data-toggle="collapse" href="#collapse_{{ divid }}">Other options<br><i class="fa fa-angle-down"></i></a>
+	<div id="collapse_{{ divid }}" class="panel-collapse collapse">
+		<hr>
+		{% include 'download/linux.twig' %}
+	</div>
 </div>
 
 <div id="windows-div" class="text-center hidden">
@@ -101,9 +124,6 @@ function showOS(os) {
 		}
 		$(os+"-button").tab("show");
 		os = "#linux";
-		$('#prerelease').hide();
-	} else {
-		$('#prerelease').show();
 	}
 
 	hide('#windows-div');

--- a/templates/download/linux.twig
+++ b/templates/download/linux.twig
@@ -3,8 +3,6 @@
 {% endblock %}
 
 <div class="text-center">
-	<h2>Install LMMS on Linux</h2>
-
 	<p>LMMS is included in most major Linux distribution's package repositories.<br>
 	Please <a href="/community/">contact us</a> if your distribution is not listed here.</p>
 

--- a/views.php
+++ b/views.php
@@ -33,17 +33,23 @@ function downloadPage()
 		$winpre = [$releases->latestWin32Asset(false), $releases->latestWin64Asset(false)];
 		$osxstable = $releases->latestOSXAssets();
 		$osxpre = $releases->latestOSXAssets(false);
+		$linstable = $releases->latestLinuxAssets();
+		$linpre = $releases->latestLinuxAssets(false);
 
-		if ($winpre[0]['created_at'] < $winstable[0]['created_at'])
+		if ($winstable && $winpre && ($winpre[0]['created_at'] < $winstable[0]['created_at']))
 			$winpre = null;
-		if ($osxpre[0]['created_at'] < $osxstable[0]['created_at'])
+		if ($osxstable && $osxpre && ($osxpre[0]['created_at'] < $osxstable[0]['created_at']))
 			$osxpre = null;
+		if ($linstable && $linpre && ($linpre[0]['created_at'] < $linstable[0]['created_at']))
+			$linpre = null;
 
 		$vars = [
 			'winstable' => $winstable,
 			'winpre' => $winpre,
 			'osxstable' => $osxstable,
-			'osxpre' => $osxpre
+			'osxpre' => $osxpre,
+			'linstable' => $linstable,
+			'linpre' => $linpre
 		];
 	} catch (Exception $e) {
 		error_log($e);


### PR DESCRIPTION
Adds the long overdue Linux `.AppImage` buttons to the downloads page.

* Moves the platform-specific download options (e.g. `apt-get install lmms`) to "Other options", collapsed by default.
* Adds Stable/Beta download button for Linux `.AppImage` files

**Note:** This should be merged only after `1.2.0-RC5` is released.

![image](https://user-images.githubusercontent.com/6345473/33568700-56b4c248-d8f5-11e7-963f-b78ed91e9392.png)

