### PR TITLE
dbo: correctly escape the download link

### DIFF
--- a/public/lsp/dbo.php
+++ b/public/lsp/dbo.php
@@ -859,7 +859,7 @@ function show_file($file_id, $user, $success = null) {
 			show_basic_file_info($object, false);
 			
 			// Bump the download button under details block
-			$url = htmlentities('download_file.php?file=' . $object['id'] . '&name=' . $object['filename']);
+			$url = 'download_file.php?file=' . $object['id'] . '&name=' . urlencode(html_entity_decode($object['filename']));
 			echo '<tr><td><strong>Name:</strong>&nbsp;' . $object['filename'];
 			if (is_image($url)) {
 				echo '<br><br><a href="' . $url . '"><img class="thumbnail" src="' . scale_image($DATA_DIR . $file_id, 300, parse_extension($url)) . '" alt=""></a>';

--- a/public/lsp/download_file.php
+++ b/public/lsp/download_file.php
@@ -10,7 +10,6 @@ require_once('dbo.php');
  */
 function download_file($file_id, $file_name) {
 	global $DATA_DIR;
-	$file_name = html_entity_decode($file_name);
 	$file_path = $DATA_DIR . $file_id;
 	if (file_exists($file_path)) {
 		increment_file_downloads($file_id);
@@ -40,6 +39,6 @@ function download_file($file_id, $file_name) {
 }
 
 if (!GET_EMPTY('file') && !GET_EMPTY('name')) {
-	download_file(GET('file'), GET('name'));
+	download_file(GET('file'), html_entity_decode(GET('name')));
 }
 ?>

--- a/public/lsp/download_file.php
+++ b/public/lsp/download_file.php
@@ -9,7 +9,8 @@ require_once('dbo.php');
  * the file as a new page
  */
 function download_file($file_id, $file_name) {
-    global $DATA_DIR;
+	global $DATA_DIR;
+	$file_name = html_entity_decode($file_name);
 	$file_path = $DATA_DIR . $file_id;
 	if (file_exists($file_path)) {
 		increment_file_downloads($file_id);


### PR DESCRIPTION
Fixes #276

Known issues:

- Because the way LSP stores the file name is problematic, if a file is named `You & Me`, the database will record `You &amp; Me` instead. I think the problem lies here: https://github.com/LMMS/lmms.io/blob/6fe9697435a6a546801bcd35a610e4ac85e28b08/public/lsp/add_file.php#L31

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lmms/lmms.io/279)
<!-- Reviewable:end -->
