### PR TITLE
CRITICAL: Patch ability to create admin accounts + other general fixes

### DIFF
--- a/public/lsp/dbo.php
+++ b/public/lsp/dbo.php
@@ -967,6 +967,11 @@ function update_rating($file_id, $stars, $user) {
 	
 	$dbh = &get_db();
 	if ($user_id >= 0) {
+		// Makes sure that the user who is rating is not the owner of the file
+		if (get_file_owner($file_id) == get_user_id(SESSION())) {
+			echo '<h3 class="text-danger">You cannot rate your own file.<h3>';
+			return;
+		}
 		$stmt = null;
 		if (get_user_rating($file_id, $user) > 0) {
 			$stmt = $dbh->prepare('UPDATE ratings SET stars=:stars WHERE file_id=:file_id AND user_id=:user_id');

--- a/public/lsp/dbo.php
+++ b/public/lsp/dbo.php
@@ -290,9 +290,10 @@ function add_user($login, $realname, $pass, $is_admin = false) {
 	$stmt->bindParam(':realname', $realname);
 	$stmt->bindParam(':password', $pass);
 	$stmt->bindParam(':is_admin', $admin);
-	$stmt->execute();
+	$success = $stmt->execute();
 	$stmt = null;
 	$dbh = null;
+	return $success;
 }
 
  /*
@@ -782,7 +783,8 @@ function show_basic_file_info($rs, $browsing_mode = false, $show_author = true) 
 		echo "<b>Size:</b>&nbsp;$hr_size<br>";
 		echo "<b>License:</b>&nbsp;$rs[license]<br>";
 		if (($project_data = read_project($rs['id'])) != null) {
-			echo "<b>LMMS Version:</b>&nbsp;" . $project_data->attributes()['creatorversion'];
+			// Since the version will normaly only have "." anyways this sanitize should work fine with replacing all dangerous charactes with "."
+			echo "<b>LMMS Version:</b>&nbsp;" . sanitize($project_data->attributes()['creatorversion'], false, '.');
 		}
 	}
 	echo "</div></td><td class=\"lsp-file-info\"><small>";

--- a/public/lsp/register.php
+++ b/public/lsp/register.php
@@ -22,8 +22,12 @@ function try_add_user($login , $pass, $pass2, $realname, $session, $is_admin, $a
 	} else if(get_user_id($login) > 0) {
 		display_error("The user <strong>$login</strong> already exists.");
 	} else {
-		add_user($login, $realname, $pass, $is_admin);
-		$return_val = display_success("<strong>$login</strong> has been successfully created");
+		if (add_user($login, $realname, $pass, $is_admin)) {
+			$return_val = display_success("<strong>$login</strong> has been successfully created");
+		} else {
+			// Will proboly not show very often
+			display_error("Unknown error, please try again later.");
+		}
 	}
 	return $return_val;
 }

--- a/public/lsp/register.php
+++ b/public/lsp/register.php
@@ -52,7 +52,7 @@ $control = POST("control", false);
 /*
  * Create the HTML form used for registration
  */
-if ((POST("adduser") != "Register") || (!try_add_user(POST("login"), POST("password"), POST("password2"), POST("realname"), POST("session"), $control, POST("antispam")))) {
+if ((POST("adduser") != "Register") || (!try_add_user(POST("login"), POST("password"), POST("password2"), POST("realname"), POST("session"), false/*$control*/, POST("antispam")))) {
 	echo '<div class="col-md-9">';
 	$form = new form($LSP_URL . '?action=register', 'Register', 'fa-list-alt'); ?>
 	<div class="form-group">

--- a/public/lsp/utils.php
+++ b/public/lsp/utils.php
@@ -178,8 +178,8 @@ function file_show_query_string() {
 /*
  * Basic column/field-name sanitization by removing non alpha-numeric characters from the input string
  */
-function sanitize($string, $tolower = false) {
-	$return_val = preg_replace('/[^A-Za-z0-9_]+/', '', $string);
+function sanitize($string, $tolower = false, $replacewith='') {
+	$return_val = preg_replace('/[^A-Za-z0-9_]+/', $replacewith, $string);
 	return $tolower ? $return_val : strtolower($return_val);
 }
 


### PR DESCRIPTION
This pull request has four changes:
1) Fix a security flaw which allows the creation of admin accounts.
2) Fixes a old XSS method involving the version of a file, the fix replaces all "dangerous characters" with a dot, this should not effect the common users since the only dangerous character in a normal version string is a dot
3) Checks if the account creation has been successful before saying that the creation was a success, this may help with the confusion of some users in the rare case the database fails to insert the new account.
4) Adds a server side check which makes sure that the user who is rating the file is not the owner of the file.

Example of the old xss method: https://lmms.io/lsp/?action=show&file=15972
Username of an account I created using the admin account creation flaw: NotAnAdmin