### PR TITLE
Update "get involved" section

### DIFF
--- a/templates/get-involved.twig
+++ b/templates/get-involved.twig
@@ -23,7 +23,7 @@
 					   coding!{% endtrans %}</p>
 					<p>{% trans %}See our <a href="//github.com/LMMS/lmms/wiki">GitHub Wiki</a> and our
 					   <a href="//github.com/LMMS/lmms/issues">bug tracker</a> to get started. Furthermore, the LMMS
-					   <a href="https://lists.sourceforge.net/lists/listinfo/lmms-devel">mailing list</a> is a great place
+					   <a href="/chat/">Discord server</a> is a great place
 					   to introduce yourself.{% endtrans %}</p>
 				</div>
 			</div>
@@ -36,10 +36,10 @@
 				</div>
 				<div class="panel-body">
 					<p>{% trans %}You can help us by improving this website or documenting the software. The website sources are in our
-					   GitHub repo <a href="//github.com/LMMS/lmms.io">LMMS/lmms.io</a>, our documentation is hosted using a
-					   <a href="//lmms.io/wiki">MediaWiki instance</a>.{% endtrans %}</p>
+					   GitHub repo <a href="//github.com/LMMS/lmms.io">LMMS/lmms.io</a>, our documentation is hosted on
+					   <a href="//docs.lmms.io/">GitBook</a>.{% endtrans %}</p>
 					<p>{% trans %}Public registration on our Wiki is disabled due to spam issues. Please post to the
-					   <a href="https://lists.sourceforge.net/lists/listinfo/lmms-devel">mailing list</a> if you're
+					   <a href="//discord.gg/pZZaPZRZ35">#website</a> channel on Discord if you're
 					   interested in helping out with the documentation!{% endtrans %}</p>
 				</div>
 			</div>
@@ -82,31 +82,30 @@
 	<div class="row">
 		<div class="col-sm-6">
 			<div class="panel panel-custom">
+				<div class="panel-heading" id="irc">
+					<h3 class="panel-title"><i class="fas fa-fw fa-comment-alt"></i> Discord &amp; IRC</h3>
+				</div>
+				<div class="panel-body">
+					<p>{% trans %}<a href="https://discordapp.com/">Discord</a>
+					is the most active forum for LMMS development. Join our server 
+					<a href="/chat/">by clicking here</a>.{% endtrans %}</p>
+					<p>{% trans %}Our IRC channel is <a href="http://webchat.freenode.net/?channels=%23lmms">#lmms</a> on
+					<a href="https://freenode.net">Freenode</a>.{% endtrans %}</p>
+				</div>
+			</div>
+		</div>
+		
+		<div class="col-sm-6">
+			<div class="panel panel-custom">
 				<div class="panel-heading" id="mailinglist">
 					<h3 class="panel-title"><i class="fas fa-fw fa-envelope"></i> {% trans %}Mailing List{% endtrans %}</h3>
 				</div>
 				<div class="panel-body">
-					<p>{% trans %}Posting to the mailing list is the best way to reach out to our developers:{% endtrans %} </p>
+					<p>{% trans %}Posting to the mailing list is another way to reach out to our developers:{% endtrans %} </p>
 					<p><a href="http://lists.sourceforge.net/lists/listinfo/lmms-devel">{% trans %}Subscribe to LMMS-Devel mailing list{% endtrans %}</a></p>
 				</div>
 			</div>
 		</div>
-
-		<div class="col-sm-6">
-			<div class="panel panel-custom">
-				<div class="panel-heading" id="irc">
-					<h3 class="panel-title"><i class="fas fa-fw fa-comment-alt"></i> IRC &amp; Discord</h3>
-				</div>
-				<div class="panel-body">
-					<p>{% trans %}Our IRC channel is <a href="http://webchat.freenode.net/?channels=%23lmms">#lmms</a> on
-					<a href="https://freenode.net">Freenode</a>.{% endtrans %}</p>
-					<p>{% trans %}<a href="https://discordapp.com/">Discord</a>
-					is a more modern alternative to IRC. Join our server 
-					<a href="/chat/">by clicking here</a>.{% endtrans %}</p>
-				</div>
-			</div>
-		</div>
-
 	</div>
 
 	<div class="row">

--- a/templates/get-involved.twig
+++ b/templates/get-involved.twig
@@ -38,7 +38,7 @@
 					<p>{% trans %}You can help us by improving this website or documenting the software. The website sources are in our
 					   GitHub repo <a href="//github.com/LMMS/lmms.io">LMMS/lmms.io</a>, our documentation is hosted on
 					   <a href="//docs.lmms.io/">GitBook</a>.{% endtrans %}</p>
-					<p>{% trans %}Public registration on our Wiki is disabled due to spam issues. Please post to the
+					<p>{% trans %}Please post to the
 					   <a href="//discord.gg/pZZaPZRZ35">#website</a> channel on Discord if you're
 					   interested in helping out with the documentation!{% endtrans %}</p>
 				</div>
@@ -83,14 +83,12 @@
 		<div class="col-sm-6">
 			<div class="panel panel-custom">
 				<div class="panel-heading" id="irc">
-					<h3 class="panel-title"><i class="fas fa-fw fa-comment-alt"></i> Discord &amp; IRC</h3>
+					<h3 class="panel-title"><i class="fas fa-fw fa-comment-alt"></i> Chat</h3>
 				</div>
 				<div class="panel-body">
 					<p>{% trans %}<a href="https://discordapp.com/">Discord</a>
 					is the most active forum for LMMS development. Join our server 
 					<a href="/chat/">by clicking here</a>.{% endtrans %}</p>
-					<p>{% trans %}Our IRC channel is <a href="http://webchat.freenode.net/?channels=%23lmms">#lmms</a> on
-					<a href="https://freenode.net">Freenode</a>.{% endtrans %}</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Properly closes #264

A few questions before merge:
- Should we still mention the mailing list at all?
- Given the [ongoing situation](https://arstechnica.com/gadgets/2021/05/freenode-irc-has-been-taken-over-by-the-crown-prince-of-korea/) with Freenode, should we remove that link? I know that @probonopd (author of AppImage, for anyone unaware) has moved. (Apologies for the ping, but perhaps you have some advice on migrating?)