### PR TITLE
Add downloads for nightlies and pull requests

### DIFF
--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ APP_SECRET=c55366de7d2b4845909b31d21b076b40
 ###< symfony/framework-bundle ###
 
 ###> knplabs/github-api ###
-GITHUB_AUTH_METHOD=http_password
+GITHUB_AUTH_METHOD=client_id_header
 GITHUB_USERNAME=username
 GITHUB_SECRET=password_or_token
 ###< knplabs/github-api ###

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -15,5 +15,6 @@ framework:
         #app: cache.adapter.apcu
 
         # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+        pools:
+            github_api.cache:
+                adapter: cache.adapter.filesystem

--- a/config/packages/github_api.yaml
+++ b/config/packages/github_api.yaml
@@ -1,9 +1,11 @@
 services:
     Github\Client:
+        class: LMMS\GithubDownloadClient
         arguments:
             - '@Github\HttpClient\Builder'
         calls:
            - ['authenticate', ['%env(GITHUB_USERNAME)%', '%env(GITHUB_SECRET)%', '%env(GITHUB_AUTH_METHOD)%']]
+           - ['addCache', ['@github_api.cache', {default_ttl: 1800}]]
 
     Github\HttpClient\Builder:
         arguments:

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -27,6 +27,14 @@ download:
    path: /download
    controller: App\Controller\DownloadController::page
 
+download_pr:
+   path: /download/pull-request/{id}
+   controller: App\Controller\DownloadController::pull_request
+
+download_artifact:
+   path: /download/artifact/{id}
+   controller: App\Controller\DownloadController::artifact
+
 portal_pages:
    path: /{page}
    controller: App\Controller\PortalController::page

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,10 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        bind:
+            string $owner: LMMS
+            string $repo: lmms
+            string $workflow: build.yml
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/lib/Artifacts.php
+++ b/lib/Artifacts.php
@@ -1,0 +1,127 @@
+<?php
+namespace LMMS;
+
+use Github\Client;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class Artifacts
+{
+	public function __construct(
+		private Client $client,
+		private string $owner,
+		private string $repo,
+		private string $workflow,
+		private UrlGeneratorInterface $router
+	)
+	{ }
+
+	public function getForBranch(string $branch): array
+	{
+		// Get the latest successful runs of the target workflow
+		$runs = $this->client->repo()->workflowRuns()->listRuns($this->owner, $this->repo, $this->workflow, [
+			'event' => 'push',
+			'branch' => $branch,
+			'status' => 'success',
+			'per_page' => 1
+		]);
+		if ($runs['total_count'] > 0) {
+			// Get all artifacts of that run
+			$runId = $runs['workflow_runs'][0]['id'];
+			$artifacts = $this->client->repo()->artifacts()->runArtifacts($this->owner, $this->repo, $runId);
+
+			$validArtifacts = array_filter($artifacts['artifacts'], function ($artifact) {
+				return !$artifact['expired'];
+			});
+			return $this->mapBranchAssetsFromJson($validArtifacts);
+		}
+		return [];
+	}
+
+	public function getForPullRequest(int $id): array
+	{
+		// Get the most recent commit in the pull request
+		$pr = $this->client->pr()->show($this->owner, $this->repo, $id);
+		$ref = $pr['head']['sha'];
+
+		// Get all check runs for that commit
+		$checks = $this->client->repo()->checkRuns()->allForReference($this->owner, $this->repo, $ref);
+
+		// Find a check run corresponding to the GitHub Actions build workflow
+		foreach ($checks['check_runs'] as $run) {
+			if ($run['app']['slug'] === 'github-actions' && $run['name'] === 'linux') {
+				$jobId = $run['id'];
+			}
+		}
+		if (!isset($jobId)) { return []; }
+
+		// Get the GitHub Actions workflow run corresponding to that check run
+		$job = $this->client->repo()->workflowJobs()->show($this->owner, $this->repo, $jobId);
+		$runId = $job['run_id'];
+
+		// Get all artifacts of that workflow run
+		$artifacts = $this->client->repo()->artifacts()->runArtifacts($this->owner, $this->repo, $runId);
+
+		$validArtifacts = array_filter($artifacts['artifacts'], function ($artifact) {
+			return !$artifact['expired'];
+		});
+		$description = '## ' . $pr['title'] . "\n" . $pr['body'];
+		return $this->mapPullRequestAssetsFromJson($validArtifacts, $id, $description);
+	}
+
+	public function getArtifactDownloadUrl(int $artifactId): string
+	{
+		return (string) $this->client->repo()->artifacts()->download($this->owner, $this->repo, $artifactId);
+	}
+
+	private function mapBranchAssetsFromJson(array $json): array
+	{
+		return array_map(function (array $artifact) {
+			return new Asset(
+				platform: self::platformFromArtifactName($artifact['name']),
+				platformName: self::platformNameFromArtifactName($artifact['name']),
+				releaseName: 'g' . substr($artifact['workflow_run']['head_sha'], 0, 9),
+				downloadUrl: $this->router->generate('download_artifact', ['id' => $artifact['id']]),
+				description: null,
+				gitRef: $artifact['workflow_run']['head_sha'],
+				date: $artifact['created_at']
+			);
+		}, $json);
+	}
+
+	private function mapPullRequestAssetsFromJson(array $json, string $pr, string $description): array
+	{
+		return array_map(function (array $artifact) use ($pr, $description) {
+			return new Asset(
+				platform: self::platformFromArtifactName($artifact['name']),
+				platformName: self::platformNameFromArtifactName($artifact['name']),
+				releaseName: '#' . $pr . '@' . substr($artifact['workflow_run']['head_sha'], 0, 9),
+				downloadUrl: $this->router->generate('download_artifact', ['id' => $artifact['id']]),
+				description: $description,
+				gitRef: $artifact['workflow_run']['head_sha'],
+				date: $artifact['created_at']
+			);
+		}, $json);
+	}
+
+	private static function platformFromArtifactName(string $artifactName): Platform
+	{
+		switch ($artifactName) {
+			case 'linux': return Platform::Linux;
+			case 'macos': return Platform::MacOS;
+			case 'mingw32': return Platform::Windows;
+			case 'mingw64': return Platform::Windows;
+			default: return Platform::Unknown;
+		}
+	}
+
+	private static function platformNameFromArtifactName(string $artifactName): string
+	{
+		switch($artifactName) {
+			case 'linux': return 'Linux 64-bit';
+			case 'macos': return 'macOS 10.15+';
+			case 'mingw32': return 'Windows 32-bit';
+			case 'mingw64': return 'Windows 64-bit';
+			default: return 'Unknown (' . $artifactName . ')';
+		}
+	}
+}

--- a/lib/Asset.php
+++ b/lib/Asset.php
@@ -1,0 +1,51 @@
+<?php
+namespace LMMS;
+
+class Asset
+{
+	public function __construct(
+		private Platform $platform,
+		private string $platformName,
+		private string $releaseName,
+		private string $downloadUrl,
+		private ?string $description,
+		private string $gitRef,
+		private string $date
+	)
+	{ }
+
+	public function getPlatform(): Platform
+	{
+		return $this->platform;
+	}
+
+	public function getPlatformName(): string
+	{
+		return $this->platformName;
+	}
+
+	public function getReleaseName(): string
+	{
+		return $this->releaseName;
+	}
+
+	public function getDownloadUrl(): string
+	{
+		return $this->downloadUrl;
+	}
+
+	public function getDescription(): ?string
+	{
+		return $this->description;
+	}
+
+	public function getGitRef(): string
+	{
+		return $this->gitRef;
+	}
+
+	public function getDate(): string
+	{
+		return $this->date;
+	}
+}

--- a/lib/GitHubMarkdownEngine.php
+++ b/lib/GitHubMarkdownEngine.php
@@ -9,13 +9,9 @@ use Aptoma\Twig\Extension\MarkdownEngineInterface;
 
 class GitHubMarkdownEngine implements MarkdownEngineInterface
 {
-	public function __construct()
+	public function __construct(private \Github\Client $client)
 	{
 		$this->cache = new FilesystemAdapter();
-		$this->client = new \Github\Client();
-		$this->client->addCache($this->cache, [
-			'default_ttl' => 7200
-		]);
 	}
 
 	public function transform($content): string
@@ -26,9 +22,9 @@ class GitHubMarkdownEngine implements MarkdownEngineInterface
 			if (substr_compare('|GH|', $content, 0, 4) === 0) {
 				$content = substr($content, 4, strlen($content));
 				try {
-					$response = $this->client->api('markdown')->render($content, 'gfm', 'LMMS/lmms');
+					$response = $this->client->markdown()->render($content, 'gfm', 'LMMS/lmms');
 					return $response;
-				} catch (Exception $e) {
+				} catch (\Exception $e) {
 					error_log($e);
 					return MarkdownExtra::defaultTransform($content);
 				}
@@ -43,6 +39,5 @@ class GitHubMarkdownEngine implements MarkdownEngineInterface
 		return 'LMMS\GitHubMarkdown';
 	}
 
-	private $client;
 	private $cache;
 }

--- a/lib/GithubDownloadClient.php
+++ b/lib/GithubDownloadClient.php
@@ -1,0 +1,42 @@
+<?php
+namespace LMMS;
+
+use Github\Client;
+use Github\HttpClient\Builder;
+use Http\Client\Common\Plugin;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Extends the KNP Labs GitHub Client to provide URLs for artifact downloads,
+ * rather than the artifacts themselves.
+ */
+class GithubDownloadClient extends Client
+{
+	public function __construct(Builder $httpClientBuilder = null, $apiVersion = null, $enterpriseUrl = null)
+	{
+		parent::__construct($httpClientBuilder, $apiVersion, $enterpriseUrl);
+		$this->getHttpClientBuilder()->addPlugin(new class implements Plugin {
+			public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+			{
+				return $next($request)->then(function(ResponseInterface $response): ResponseInterface {
+					if ($response->getStatusCode() === 302) {
+						$location = $response->getHeader('Location')[0];
+						if (str_starts_with($location, 'https://pipelines.actions.githubusercontent.com')) {
+							$body = Psr17FactoryDiscovery::findStreamFactory()->createStream($location);
+							$body->rewind();
+							return $response
+								->withStatus(200)
+								->withHeader('Content-Type', 'text/plain')
+								->withoutHeader('Location')
+								->withBody($body);
+						}
+					}
+					return $response;
+				});
+			}
+		});
+	}
+}

--- a/lib/Platform.php
+++ b/lib/Platform.php
@@ -1,0 +1,10 @@
+<?php
+namespace LMMS;
+
+enum Platform
+{
+	case Unknown;
+	case Linux;
+	case MacOS;
+	case Windows;
+}

--- a/lib/Releases.php
+++ b/lib/Releases.php
@@ -1,27 +1,31 @@
 <?php
 namespace LMMS;
 
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Contracts\Cache\ItemInterface;
+use Github\Client;
 
 class Releases
 {
-	public function __construct($owner='LMMS', $repo='lmms')
+	public function __construct(Client $client, string $owner, string $repo)
 	{
-		$this->cache = new FilesystemAdapter();
-		$this->client = new \Github\Client();
-		$this->client->addCache($this->cache, [
-			'default_ttl' => 1800
-		]);
-		$this->json = $this->client->api('repo')->releases()->all($owner, $repo);
+		$this->json = $client->repo()->releases()->all($owner, $repo);
 		usort($this->json, function ($a, $b) {
 			return version_compare($b['tag_name'], $a['tag_name']);
 		});
 	}
 
-	public function latestAssets($pattern, $stable = true)
+	public function latestStableAssets(): array
 	{
-		foreach ($this->json as $index => $release) {
+		return $this->latestAssets(true);
+	}
+
+	public function latestUnstableAssets(): array
+	{
+		return $this->latestAssets(false);
+	}
+
+	private function latestAssets(bool $stable = true): array
+	{
+		foreach ($this->json as $release) {
 			if ($release['draft']) {
 				continue;
 			}
@@ -29,54 +33,33 @@ class Releases
 				continue;
 			}
 
-			$assets = [];
-			foreach($release['assets'] as $asset)
-			{
-				if (preg_match($pattern, $asset['name']))
-				{
-					$asset['release'] = $release;
-					$asset['osname'] = $this->osName($asset['name']);
-					$asset['release']['index'] = $index;
-					array_push($assets, $asset);
-				}
-			}
-			return $assets;
+			return $this->mapAssetsFromJson($release);
 		}
+		return [];
 	}
 
-	public function latestAsset($pattern, $stable = true)
+	private function mapAssetsFromJson(array $json): array
 	{
-		$assets = $this->latestAssets($pattern, $stable);
-		return $assets ? array_pop($assets) : null;
-	}
-
-	public function latestWin32Asset($stable = true)
-	{
-		return $this->latestAsset('/.*-win32\.exe/i', $stable);
-	}
-
-	public function latestWin64Asset($stable = true)
-	{
-		return $this->latestAsset('/.*-win64\.exe/i', $stable);
-	}
-
-	public function latestOSXAssets($stable = true)
-	{
-		return $this->latestAssets('/.*\.dmg/', $stable);
-	}
-
-	public function latestLinuxAssets($stable = true)
-	{
-		return $this->latestAssets('/.*\.AppImage/', $stable);
+		return array_map(function (array $asset) use ($json) {
+			return new Asset(
+				platform: self::platformFromAssetName($asset['name']),
+				platformName: self::platformNameFromAssetName($asset['name']),
+				releaseName: $json['name'],
+				downloadUrl: $asset['browser_download_url'],
+				description: $json['body'],
+				gitRef: $json['tag_name'],
+				date: $asset['created_at']
+			);
+		}, $json['assets']);
 	}
 
 	/*
 	 * Get "32-bit", "64-bit", etc based on Download URL
 	 */
-	private function get_arch($text) {
+	private static function getArchitectureFromAssetName(string $assetName): string {
 		$arch64 = array('amd64', 'win64', 'x86-64', 'x86_64', 'x64', '64-bit', '.dmg');
 		foreach ($arch64 as $x) {
-			if (strpos(strtolower($text), $x) !== false) {
+			if (strpos(strtolower($assetName), $x) !== false) {
 				return '64-bit';
 			}
 		}
@@ -86,35 +69,50 @@ class Releases
 	/*
 	 * Get "10.11", etc based on Download URL
 	 */
-	private function get_osver($text) {
-		if (strpos($text, '.dmg') !== false) {
-			$parts = explode('-', explode('.dmg', $text)[0]);
+	private static function getOsVersionFromAssetName(string $assetName): string {
+		if (strpos($assetName, '.dmg') !== false) {
+			$parts = explode('-', explode('.dmg', $assetName)[0]);
 			return filter_var(array_pop($parts), FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
 		}
 		return 'all';
 	}
 
+	private static function platformFromAssetName(string $assetName): Platform {
+		if (strpos($assetName, '.deb') !== false) {
+			return Platform::Linux;
+		} else if (strpos($assetName, '.rpm') !== false) {
+			return Platform::Linux;
+		} else if (strpos($assetName, '.dmg') !== false) {
+			return Platform::MacOS;
+		} else if (strpos($assetName, '.exe') !== false) {
+			return Platform::Windows;
+		} else if (strpos($assetName, '.AppImage') !== false) {
+			return Platform::Linux;
+		} else {
+			return Platform::Unknown;
+		}
+	}
+
 	/*
 	 * Get "Windows", "Apple", etc based on Download URL
 	 */
-	private function osName($text) {
-		if (strpos($text, '.tar.') !== false) {
+	private static function platformNameFromAssetName(string $assetName): string {
+		if (strpos($assetName, '.tar.') !== false) {
 			return 'Source Tarball';
-		} else if (strpos($text, '.deb') !== false) {
-			return 'Ubuntu ' . $this->get_arch($text);
-		} else if (strpos($text, '.rpm') !== false) {
-			return 'Fedora ' . $this->get_arch($text);
-		} else if (strpos($text, '.dmg') !== false) {
-			return 'macOS ' . $this->get_osver($text) . '+';
-		} else if (strpos($text, '.exe') !== false) {
-			return 'Windows ' . $this->get_arch($text);
-		} else if (strpos($text, '.AppImage') !== false) {
-			return 'Linux ' . $this->get_arch($text);
+		} else if (strpos($assetName, '.deb') !== false) {
+			return 'Ubuntu ' . self::getArchitectureFromAssetName($assetName);
+		} else if (strpos($assetName, '.rpm') !== false) {
+			return 'Fedora ' . self::getArchitectureFromAssetName($assetName);
+		} else if (strpos($assetName, '.dmg') !== false) {
+			return 'macOS ' . self::getOsVersionFromAssetName($assetName) . '+';
+		} else if (strpos($assetName, '.exe') !== false) {
+			return 'Windows ' . self::getArchitectureFromAssetName($assetName);
+		} else if (strpos($assetName, '.AppImage') !== false) {
+			return 'Linux ' . self::getArchitectureFromAssetName($assetName);
 		} else {
-			return $text;
+			return $assetName;
 		}
 	}
 
 	private $json;
-	private $client;
 }

--- a/lib/Releases.php
+++ b/lib/Releases.php
@@ -57,7 +57,7 @@ class Releases
 	 * Get "32-bit", "64-bit", etc based on Download URL
 	 */
 	private static function getArchitectureFromAssetName(string $assetName): string {
-		$arch64 = array('amd64', 'win64', 'x86-64', 'x86_64', 'x64', '64-bit', '.dmg');
+		$arch64 = array('aarch64', 'arm64', 'riscv64', 'amd64', 'win64', 'x86-64', 'x86_64', 'x64', '64-bit', '.dmg');
 		foreach ($arch64 as $x) {
 			if (strpos(strtolower($assetName), $x) !== false) {
 				return '64-bit';

--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -1,45 +1,99 @@
 <?php
 namespace App\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
-use App\Navbar\navbar;
+use LMMS\Artifacts;
+use LMMS\Asset;
+use LMMS\Platform;
 use LMMS\Releases;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
 
 class DownloadController extends AbstractController
 {
-    public function page(Request $request)
+    public function page(Releases $releases, Artifacts $artifacts): Response
     {
         try {
-            $releases = new Releases();
-    
-            $winstable = [$releases->latestWin32Asset(), $releases->latestWin64Asset()];
-            $winpre = [$releases->latestWin32Asset(false), $releases->latestWin64Asset(false)];
-            $osxstable = $releases->latestOSXAssets();
-            $osxpre = $releases->latestOSXAssets(false);
-            $linstable = $releases->latestLinuxAssets();
-            $linpre = $releases->latestLinuxAssets(false);
-    
-            if ($winstable[0] && $winpre[0] && ($winpre[0]['created_at'] < $winstable[0]['created_at']))
+            $assets = $releases->latestStableAssets();
+            $winstable = array_values(array_filter($assets, self::assetsForPlatform(Platform::Windows)));
+            $osxstable = array_values(array_filter($assets, self::assetsForPlatform(Platform::MacOS)));
+            $linstable = array_values(array_filter($assets, self::assetsForPlatform(Platform::Linux)));
+
+            $assets = $releases->latestUnstableAssets();
+            $winpre = array_values(array_filter($assets, self::assetsForPlatform(Platform::Windows)));
+            $osxpre = array_values(array_filter($assets, self::assetsForPlatform(Platform::MacOS)));
+            $linpre = array_values(array_filter($assets, self::assetsForPlatform(Platform::Linux)));
+
+            if ($winstable && $winpre && ($winpre[0]->getDate() < $winstable[0]->getDate()))
                 $winpre = null;
-            if ($osxstable && $osxpre && ($osxpre[0]['created_at'] < $osxstable[0]['created_at']))
+            if ($osxstable && $osxpre && ($osxpre[0]->getDate() < $osxstable[0]->getDate()))
                 $osxpre = null;
-            if ($linstable && $linpre && ($linpre[0]['created_at'] < $linstable[0]['created_at']))
+            if ($linstable && $linpre && ($linpre[0]->getDate() < $linstable[0]->getDate()))
                 $linpre = null;
-    
+
+            $assets = $artifacts->getForBranch('master');
+            $winnightly = array_values(array_filter($assets, self::assetsForPlatform(Platform::Windows)));
+            $osxnightly = array_values(array_filter($assets, self::assetsForPlatform(Platform::MacOS)));
+            $linnightly = array_values(array_filter($assets, self::assetsForPlatform(Platform::Linux)));
+
             $vars = [
                 'winstable' => $winstable,
                 'winpre' => $winpre,
+                'winnightly' => $winnightly,
                 'osxstable' => $osxstable,
                 'osxpre' => $osxpre,
+                'osxnightly' => $osxnightly,
                 'linstable' => $linstable,
-                'linpre' => $linpre
+                'linpre' => $linpre,
+                'linnightly' => $linnightly
             ];
-        } catch (Exception $e) {
+            return $this->render('download/index.twig', $vars);
+        } catch (\Exception $e) {
             error_log($e);
             return $this->render('download/error.twig');
         }
-    
-        return $this->render('download/index.twig', $vars);
+    }
+
+    public function pull_request(string $id, Artifacts $artifacts): Response
+    {
+        try {
+            $assets = $artifacts->getForPullRequest($id);
+            $winartifacts = array_values(array_filter($assets, self::assetsForPlatform(Platform::Windows)));
+            $osxartifacts = array_values(array_filter($assets, self::assetsForPlatform(Platform::MacOS)));
+            $linartifacts = array_values(array_filter($assets, self::assetsForPlatform(Platform::Linux)));
+
+            $vars = [
+                'id' => $id,
+                'winartifacts' => $winartifacts,
+                'osxartifacts' => $osxartifacts,
+                'linartifacts' => $linartifacts
+            ];
+            return $this->render('download/pull-request.twig', $vars);
+        } catch (\Exception $e) {
+            if ($e->getCode() === 404) {
+                throw $this->createNotFoundException(previous: $e);
+            }
+            error_log($e);
+            return $this->render('download/error.twig');
+        }
+    }
+
+    public function artifact(string $id, Artifacts $artifacts): Response
+    {
+        try {
+            return $this->redirect($artifacts->getArtifactDownloadUrl($id));
+        } catch (\Exception $e) {
+            if ($e->getCode() === 404) {
+                throw $this->createNotFoundException(previous: $e);
+            }
+            error_log($e);
+            return $this->render('download/error.twig');
+        }
+    }
+
+    private static function assetsForPlatform(Platform $platform)
+    {
+        return function (Asset $asset) use ($platform) {
+            return $asset->getPlatform() === $platform;
+        };
     }
 }

--- a/templates/download/error.twig
+++ b/templates/download/error.twig
@@ -1,5 +1,16 @@
 {% extends 'base.twig' %}
 
+{% import 'macros.twig' as macros %}
+
 {% block content %}
-<p>{% trans %}We're sorry, something went wrong fetching the latest release info. You can still download releases on <a href="//github.com/LMMS/lmms/releases">GitHub</a>.{% endtrans %}</p>
+{{ macros.jumbo('Download LMMS'|trans,
+'Downloading and using LMMS is free! Just choose the operating system you want to run LMMS on:'|trans) }}
+<div class="container text-center">
+	<p>
+		{% trans %}We're sorry, something went wrong fetching the latest release info. You can still download releases on <a href="//github.com/LMMS/lmms/releases">GitHub</a>.{% endtrans %}
+	</p>
+</div>
+{% endblock %}
+
+{% block foot %}
 {% endblock %}

--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -45,7 +45,6 @@
 	{% if pre %}
 		<h3>
 		{% if 'alpha' in pre[0].gitRef %}
-		{% if 'alpha' in linpre[0].release.tag_name %}
 			{% trans %}Alpha Versions{% endtrans %}
 		{% else %}
 			{% trans %}Beta Versions{% endtrans %}

--- a/templates/download/linux.twig
+++ b/templates/download/linux.twig
@@ -2,109 +2,113 @@
 	<link href="//cdnjs.cloudflare.com/ajax/libs/font-linux/0.9/font-linux.min.css" rel="stylesheet">
 {% endblock %}
 
-<div class="text-center">
-	<p>{% trans %}LMMS is included in most major Linux distribution's package repositories.<br>
-	Please <a href="/get-involved/#contact">contact us</a> if your distribution is not listed here.{% endtrans %}</p>
+<hr>
+<a data-toggle="collapse" href="#collapse_lin_other">{% trans %}Other options{% endtrans %}<br><i class="fas fa-angle-down"></i></a>
+<div id="collapse_lin_other" class="panel-collapse collapse">
+	<div class="text-center">
+		<p>{% trans %}LMMS is included in most major Linux distribution's package repositories.<br>
+		Please <a href="/get-involved/#contact">contact us</a> if your distribution is not listed here.{% endtrans %}</p>
 
-	<div class="nav-center-container">
-		<ul id="linux-tabs" class="nav nav-tabs nav-center" role="tablist">
-			<li><a href="#linux-debian" role="tab" data-toggle="tab" id="linux-debian-button" class="active">
-				<span class="visible-lg-inline"><span class="fl fl-16 fl-debian fl-tab"></span>&nbsp;Debian&nbsp;/</span>
-				<span class="fl fl-16 fl-ubuntu fl-tab"></span>&nbsp;Ubuntu
-			</a></li>
+		<div class="nav-center-container">
+			<ul id="linux-tabs" class="nav nav-tabs nav-center" role="tablist">
+				<li><a href="#linux-debian" role="tab" data-toggle="tab" id="linux-debian-button" class="active">
+					<span class="visible-lg-inline"><span class="fl fl-16 fl-debian fl-tab"></span>&nbsp;Debian&nbsp;/</span>
+					<span class="fl fl-16 fl-ubuntu fl-tab"></span>&nbsp;Ubuntu
+				</a></li>
 
-			<li><a href="#linux-suse" role="tab" data-toggle="tab" id="linux-suse-button">
-				<span class="fl fl-16 fl-opensuse fl-tab"></span>&nbsp;OpenSUSE
-			</a></li>
+				<li><a href="#linux-suse" role="tab" data-toggle="tab" id="linux-suse-button">
+					<span class="fl fl-16 fl-opensuse fl-tab"></span>&nbsp;OpenSUSE
+				</a></li>
 
-			<li><a href="#linux-mageia" role="tab" data-toggle="tab" id="linux-mageia-button">
-				<span class="fl fl-16 fl-mageia fl-tab"></span>&nbsp;Mageia
-				<span class="visible-lg-inline">&nbsp;/<span class="fl fl-16 fl-mandriva fl-tab"></span>&nbsp;Mandriva</span>
-			</a></li>
+				<li><a href="#linux-mageia" role="tab" data-toggle="tab" id="linux-mageia-button">
+					<span class="fl fl-16 fl-mageia fl-tab"></span>&nbsp;Mageia
+					<span class="visible-lg-inline">&nbsp;/<span class="fl fl-16 fl-mandriva fl-tab"></span>&nbsp;Mandriva</span>
+				</a></li>
 
-			<li><a href="#linux-fedora" role="tab" data-toggle="tab" id="linux-fedora-button">
-				<span class="fl fl-16 fl-fedora fl-tab"></span>&nbsp;Fedora
-				<span class="visible-lg-inline">&nbsp;/<span class="fl fl-16 fl-redhat fl-tab"></span>&nbsp;Red Hat</span>
-			</a></li>
+				<li><a href="#linux-fedora" role="tab" data-toggle="tab" id="linux-fedora-button">
+					<span class="fl fl-16 fl-fedora fl-tab"></span>&nbsp;Fedora
+					<span class="visible-lg-inline">&nbsp;/<span class="fl fl-16 fl-redhat fl-tab"></span>&nbsp;Red Hat</span>
+				</a></li>
 
-			<li><a href="#linux-arch" role="tab" data-toggle="tab" id="linux-arch-button">
-				<span class="fl fl-16 fl-archlinux fl-tab"></span>&nbsp;Arch Linux
-			</a></li>
+				<li><a href="#linux-arch" role="tab" data-toggle="tab" id="linux-arch-button">
+					<span class="fl fl-16 fl-archlinux fl-tab"></span>&nbsp;Arch Linux
+				</a></li>
 
-			<li><a href="#linux-slackware" role="tab" data-toggle="tab" id="linux-slackware-button">
-				<span class="fl fl-16 fl-slackware fl-tab"></span>&nbsp;Slackware
-			</a></li>
+				<li><a href="#linux-slackware" role="tab" data-toggle="tab" id="linux-slackware-button">
+					<span class="fl fl-16 fl-slackware fl-tab"></span>&nbsp;Slackware
+				</a></li>
 
-			<li><a href="#linux-aosc" role="tab" data-toggle="tab" id="linux-aosc-button">
-				<span class="fl fl-16 fl-aosc fl-tab"></span>&nbsp;AOSC OS
-			</a></li>
-		</ul>
-	</div>
-</div>
-
-<div class="tab-content">
-	<div id="linux-debian" class="tab-pane active">
-		<h3>Ubuntu, Linux Mint, Debian (deb)</h3>
-		<p>{% trans %}For installing LMMS on Debian based distributions such as Debian itself, Ubuntu or Linux Mint, just click the button below.{% endtrans %}<br></p>
-		<!-- <p><a class="btn btn-primary" target="new" href="apt://lmms"><span class="fas fa-download"></span> Install LMMS</a></p> -->
-		<p>
-		<a class="btn btn-md btn-dl btn-primary" href="apt://lmms" title="apt://lmms">
-			<span class="fas fa-cloud-download-alt fa-3x download-icon"></span>
-			<span class="big">{% trans %}Install LMMS now{% endtrans %}</span><br>
-			<span class="small">{% trans %}From your package manager{% endtrans %}</span>
-		</a>
-		</p>
-		<p>{% trans %}If this doesn't work for you, run this command in a terminal.{% endtrans %}</p>
-		<div class="code-block"><pre>$ sudo apt-get install lmms</pre></div>
-		<p>{% trans %}If the traditional repositories lag behind on versions, try the <a href="https://kx.studio/Repositories#Ubuntu">KXStudio repository</a>.{% endtrans %}</p>
-		<h3>{% trans %}VST Support{% endtrans %}</h3>
-		<p>{% trans %}If your distribution offers VST support (requires the installation of Wine) it is generally offered in a separate package.  For example, using the <a href="https://kx.studio/Repositories#Ubuntu">KXStudio repository</a>, run this command in a terminal.{% endtrans %}</p>
-		<div class="code-block"><pre>$ sudo apt-get install lmms-vst-full</pre></div>
+				<li><a href="#linux-aosc" role="tab" data-toggle="tab" id="linux-aosc-button">
+					<span class="fl fl-16 fl-aosc fl-tab"></span>&nbsp;AOSC OS
+				</a></li>
+			</ul>
+		</div>
 	</div>
 
-	<div id="linux-mageia" class="tab-pane">
-		<h3>Mandriva, Mageia (rpm)</h3>
-		<p>{% trans %}Run the following command as root in a terminal:{% endtrans %}</p>
-		<div class="code-block"><pre>$ urpmi lmms</pre></div>
+	<div class="tab-content">
+		<div id="linux-debian" class="tab-pane active">
+			<h3>Ubuntu, Linux Mint, Debian (deb)</h3>
+			<p>{% trans %}For installing LMMS on Debian based distributions such as Debian itself, Ubuntu or Linux Mint, just click the button below.{% endtrans %}<br></p>
+			<!-- <p><a class="btn btn-primary" target="new" href="apt://lmms"><span class="fas fa-download"></span> Install LMMS</a></p> -->
+			<p>
+			<a class="btn btn-md btn-dl btn-primary" href="apt://lmms" title="apt://lmms">
+				<span class="fas fa-cloud-download-alt fa-3x download-icon"></span>
+				<span class="big">{% trans %}Install LMMS now{% endtrans %}</span><br>
+				<span class="small">{% trans %}From your package manager{% endtrans %}</span>
+			</a>
+			</p>
+			<p>{% trans %}If this doesn't work for you, run this command in a terminal.{% endtrans %}</p>
+			<div class="code-block"><pre>$ sudo apt-get install lmms</pre></div>
+			<p>{% trans %}If the traditional repositories lag behind on versions, try the <a href="https://kx.studio/Repositories#Ubuntu">KXStudio repository</a>.{% endtrans %}</p>
+			<h3>{% trans %}VST Support{% endtrans %}</h3>
+			<p>{% trans %}If your distribution offers VST support (requires the installation of Wine) it is generally offered in a separate package.  For example, using the <a href="https://kx.studio/Repositories#Ubuntu">KXStudio repository</a>, run this command in a terminal.{% endtrans %}</p>
+			<div class="code-block"><pre>$ sudo apt-get install lmms-vst-full</pre></div>
+		</div>
+
+		<div id="linux-mageia" class="tab-pane">
+			<h3>Mandriva, Mageia (rpm)</h3>
+			<p>{% trans %}Run the following command as root in a terminal:{% endtrans %}</p>
+			<div class="code-block"><pre>$ urpmi lmms</pre></div>
+		</div>
+
+		<div id="linux-fedora" class="tab-pane">
+			<h3>Fedora, RedHat, CentOS (rpm)</h3>
+			<p>{% trans %}Run the following command as root in a terminal:{% endtrans %}</p>
+			<div class="code-block"><pre>$ yum install lmms</pre></div>
+		</div>
+
+		<div id="linux-arch" class="tab-pane">
+			<h3>Arch Linux</h3>
+			<p>{% trans %}Run the following command in a terminal:{% endtrans %}</p>
+			<div class="code-block"><pre>$ sudo pacman -S lmms</pre></div>
+			<h3>{% trans %}VST Support{% endtrans %}</h3>
+			<p>{% trans %}For VST support, please install wine or wine-staging from the repository{% endtrans %}</p>
+		</div>
+
+		<div id="linux-slackware" class="tab-pane">
+			<h3>Slackware Linux</h3>
+			<p></p>
+			<div class="code-block"><pre># sbopkg -i fltk -i lmms</pre></div>
+		</div>
+
+		<div id="linux-suse" class="tab-pane">
+			<h3>openSUSE</h3>
+			<p>{% trans %}Run the following command in a terminal:{% endtrans %}</p>
+			<div class="code-block"><pre>$ sudo zypper install lmms</pre></div>
+		</div>
+
+		<div id="linux-aosc" class="tab-pane">
+			<h3>AOSC OS</h3>
+			<p>{% trans %}AOSC OS ships LMMS on various architectural ports (AMD64/x86_64, ARMv7, and more to come in the future), with VST support enabled by default on AMD64.{% endtrans %}</p>
+			<p>{% trans %}To install LMMS on AOSC OS with PackageKit (recommended):{% endtrans %}</p>
+			<div class="code-block"><pre>$ pkcon install lmms</pre></div>
+			<p>{% trans %}To install LMMS on AOSC OS with DPKG:{% endtrans %}</p>
+			<div class="code-block"><pre>$ sudo apt install lmms</pre></div>
+		</div>
 	</div>
 
-	<div id="linux-fedora" class="tab-pane">
-		<h3>Fedora, RedHat, CentOS (rpm)</h3>
-		<p>{% trans %}Run the following command as root in a terminal:{% endtrans %}</p>
-		<div class="code-block"><pre>$ yum install lmms</pre></div>
+	<div id="linux-source">
+		<h3>{% trans %}Build LMMS from source{% endtrans %}</h3>
+		<p>{% trans %}If your Linux distribution does not provide a lmms package (or only an outdated one), you can still build LMMS from source. Visit the <a href="https://github.com/LMMS/lmms/wiki/Compiling">LMMS development wiki on GitHub</a> for instructions on how to compile LMMS for Linux.{% endtrans %}</p>
 	</div>
-
-	<div id="linux-arch" class="tab-pane">
-		<h3>Arch Linux</h3>
-		<p>{% trans %}Run the following command in a terminal:{% endtrans %}</p>
-		<div class="code-block"><pre>$ sudo pacman -S lmms</pre></div>
-		<h3>{% trans %}VST Support{% endtrans %}</h3>
-		<p>{% trans %}For VST support, please install wine or wine-staging from the repository{% endtrans %}</p>
-	</div>
-
-	<div id="linux-slackware" class="tab-pane">
-		<h3>Slackware Linux</h3>
-		<p></p>
-		<div class="code-block"><pre># sbopkg -i fltk -i lmms</pre></div>
-	</div>
-
-	<div id="linux-suse" class="tab-pane">
-		<h3>openSUSE</h3>
-		<p>{% trans %}Run the following command in a terminal:{% endtrans %}</p>
-		<div class="code-block"><pre>$ sudo zypper install lmms</pre></div>
-	</div>
-
-	<div id="linux-aosc" class="tab-pane">
-		<h3>AOSC OS</h3>
-		<p>{% trans %}AOSC OS ships LMMS on various architectural ports (AMD64/x86_64, ARMv7, and more to come in the future), with VST support enabled by default on AMD64.{% endtrans %}</p>
-		<p>{% trans %}To install LMMS on AOSC OS with PackageKit (recommended):{% endtrans %}</p>
-		<div class="code-block"><pre>$ pkcon install lmms</pre></div>
-		<p>{% trans %}To install LMMS on AOSC OS with DPKG:{% endtrans %}</p>
-		<div class="code-block"><pre>$ sudo apt install lmms</pre></div>
-	</div>
-</div>
-
-<div id="linux-source">
-	<h3>{% trans %}Build LMMS from source{% endtrans %}</h3>
-	<p>{% trans %}If your Linux distribution does not provide a lmms package (or only an outdated one), you can still build LMMS from source. Visit the <a href="https://github.com/LMMS/lmms/wiki/Compiling">LMMS development wiki on GitHub</a> for instructions on how to compile LMMS for Linux.{% endtrans %}</p>
 </div>

--- a/templates/download/pull-request.twig
+++ b/templates/download/pull-request.twig
@@ -1,79 +1,34 @@
 {% extends 'base.twig' %}
 
-{% import _self as download %}
+{% import 'macros.twig' as macros %}
+{% import 'download/index.twig' as download %}
 
-{# Macro for printing oversized download buttons #}
-{% macro printrelbutton(rel, btnclass = 'btn-primary') %}
-	{% if rel != null %}
-		<a class="btn btn-lg btn-dl {{ btnclass }}" href="{{ rel.downloadUrl }}">
-			<span class="fas fa-cloud-download-alt fa-3x download-icon"></span>
-			<span class="big">{{ rel.platformName }}</span><br>
-			<span class="small">LMMS&nbsp;{{ rel.releaseName }}</span>
-		</a>
-	{% endif %}
-{% endmacro %}
-
-{% macro releasenotes(notes, divid) %}
-<div id="release-notes">
-	<a data-toggle="collapse" href="#collapse_{{ divid }}">{% trans %}Show release notes{% endtrans %}<br><i class="fas fa-angle-down"></i></a>
-	<div id="collapse_{{ divid }}" class="panel-collapse collapse">
-		<div class="release-notes well">
-			{{ ('|GH|' ~ notes)|markdown }}
-		</div>
-	</div>
-</div>
-{% endmacro %}
-
-{% macro osbutton(os, icon, title) %}
-<label class="btn btn-default" onclick="showOS('#{{ os }}')">
-	<input type="radio" name="options" id="{{ os }}-button"><span class="fab {{ icon }} fa-3x"></span><br>{{ title }}
-</label>
-{% endmacro %}
-
-{% macro ospage(os, title, subtitle, stable, pre, nightly, instruction, trailer) %}
+{% macro ospage(os, title, subtitle, id, artifacts, instruction, trailer) %}
 <div id="{{ os }}-div" class="text-center hidden container">
 	<h2>{{ title }}</h2>
-	<p>{{ subtitle }}</p>
-	{% if stable %}
-		<h3>{% trans %}Stable Versions{% endtrans %}</h3>
-		{% for asset in stable %}
-			{{ download.printrelbutton(asset) }}
-		{% endfor %}
-		{{ download.releasenotes(stable[0].description, "#{os}-stable") }}
-		{% if instruction %}<p>{{ instruction|raw }}</p>{% endif %}
-	{% endif %}
-	{% if pre %}
-		<h3>
-		{% if 'alpha' in pre[0].gitRef %}
-			{% trans %}Alpha Versions{% endtrans %}
-		{% else %}
-			{% trans %}Beta Versions{% endtrans %}
-		{% endif %}
-		</h3>
-		{% for asset in pre %}
-			{{ download.printrelbutton(asset, 'btn-warning') }}
-		{% endfor %}
-		{{ download.releasenotes(pre[0].description, "#{os}-pre") }}
-	{% endif %}
-	{% if nightly %}
-		<h3>{% trans %}Nightly Versions{% endtrans %}</h3>
-		{% for asset in nightly %}
+	{% if artifacts %}
+		<p>{{ subtitle }}</p>
+		<div class="alert alert-danger">
+			{% trans with {'%download%': path('download')} %}Anyone can open a pull request against LMMS; we are not responsible for the builds on this page.<br>Unless you were directed here to test a pull request, please download an official build from the <a href="%download%">main download page</a> instead.{% endtrans %}
+		</div>
+		<h3>{{ 'Pull Request #%id%'|trans({'%id%': id}) }}</h3>
+		{% for asset in artifacts %}
 			{{ download.printrelbutton(asset, 'btn-secondary') }}
 		{% endfor %}
-	{% endif %}
-	{% if pre or nightly %}
+		{{ download.releasenotes(artifacts[0].description, "#{os}-artifacts") }}
+		{% if instruction %}<p>{{ instruction|raw }}</p>{% endif %}
 		<div id="prerelease" class="text-center">
 			<small>
 				<span class="fas fa-exclamation-circle"></span>
-				{% trans %}Downloads labeled Alpha, Beta, or Nightly are pre-release software, stability may suffer.{% endtrans %}
+				{% trans %}Pull request builds are experimental software; expect stability issues.{% endtrans %}
 			</small>
 		</div>
+	{% else %}
+		<p>{% trans %}There are currently no builds available for this pull request. Building may have failed, or may not have completed yet.<br>If this is an old pull request, the builds may have expired.{% endtrans %}</p>
 	{% endif %}
 	{{ trailer|raw }}
 </div>
 {% endmacro %}
-
-{% import 'macros.twig' as macros %}
 
 {% block content %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
@@ -82,9 +37,9 @@
 <div class="text-center container">
 	<div>
 		<div class="btn-group" data-toggle="buttons">
-			{{ _self.osbutton('linux', 'fa-linux', 'Linux') }}
-			{{ _self.osbutton('windows', 'fa-windows', 'Windows') }}
-			{{ _self.osbutton('mac', 'fa-apple', 'macOS') }}
+			{{ download.osbutton('linux', 'fa-linux', 'Linux') }}
+			{{ download.osbutton('windows', 'fa-windows', 'Windows') }}
+			{{ download.osbutton('mac', 'fa-apple', 'macOS') }}
 		</div>
 	</div>
 </div>
@@ -93,35 +48,26 @@
 	'linux',
 	'Install LMMS on Linux'|trans,
 	'Click one of the buttons below to download LMMS for Linux.'|trans,
-	linstable,
-	linpre,
-	linnightly,
-	'Run <code>chmod +x ~/Downloads/*.AppImage</code> to set the <code>.AppImage</code> executable before running'|trans,
-	include('download/linux.twig')
+	id,
+	linartifacts,
+	'Run <code>chmod +x ~/Downloads/*.AppImage</code> to set the <code>.AppImage</code> executable before running'|trans
 ) }}
 
 {{ _self.ospage(
 	'windows',
 	'Install LMMS on Windows'|trans,
 	'Click one of the buttons below (either 32bit or 64bit) to download LMMS for Windows'|trans,
-	winstable,
-	winpre,
-	winnightly
+	id,
+	winartifacts
 ) }}
 
 {{ _self.ospage(
 	'mac',
 	'Install LMMS on macOS'|trans,
 	'Click one of the buttons below to download LMMS for macOS'|trans,
-	osxstable,
-	osxpre,
-	osxnightly
+	id,
+	osxartifacts
 ) }}
-
-<div class="text-center spacey container">
-	<hr>
-	<a class="btn btn-default" href="https://github.com/LMMS/lmms/tags"><i class="fas fa-history"></i> {% trans %}Previous releases{% endtrans %}</a>
-</div>
 
 <script>
 function showOS(os) {


### PR DESCRIPTION
The main changes in this PR:
* Add actual tip-of-master nightlies to the downloads page, and rename the alpha builds from "Nightly" to "Alpha".
* Add a page for downloading pull request builds.
* Add a redirect route for downloading GitHub Actions artifacts without the user needing to log in to GitHub (similar to https://nightly.link/). This is required for the nightly and pull request downloads.

Other changes:
* Updated the library classes and download controller to use Symfony's autowiring dependency injection.
* Moved the repository owner and name information into a config file.
* Fixed various catch blocks to refer to `Exception` in the root namespace.
* Added the jumbo into the download error page, so it looks a little less broken.
* Added types to various functions.
* Refactored the download templates to try and reduce code duplication slightly.

The artifact download feature requires authentication for the GitHub API, which also comes with the bonus of raising our rate limit from 60 to 3600 requests per hour. Obviously the credentials for this need to be set up separately from this PR. I've been testing this with a personal access token as it's the easiest to set up, but other options are available. I used the following in `.env.local`:
```ini
###> knplabs/github-api ###
GITHUB_AUTH_METHOD=access_token_header
GITHUB_USERNAME=[token redacted]
GITHUB_SECRET=
###< knplabs/github-api ###
```

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/1873225/200178846-223d667e-d1fc-42d7-b10d-c90664dd5c10.png)
![image](https://user-images.githubusercontent.com/1873225/200179039-dc088a4b-02a6-402b-9f34-9fd809bc910a.png)

</details>