### PR TITLE
Use correct SoundCloud link

### DIFF
--- a/templates/home.twig
+++ b/templates/home.twig
@@ -86,7 +86,7 @@
 		</div>
 		<div>
 			<div>
-				<a class="stack" href="https://soundcloud.com/search/sounds?q=%23lmms">
+				<a class="stack" href="https://soundcloud.com/tags/LMMS">
 					{{ macros.circle_stack('fa-soundcloud', 'fa-6x', true, 'Find musicians'|trans) }}</a>&nbsp;
 				<a class="stack" href="/lsp/">{{ macros.circle_stack('fa-share-alt', 'fa-6x', false, 'Visit the LMMS Sharing Platform (LSP)'|trans) }}</a>&nbsp;
 				<h4>{% trans %}Don't be modest.{% endtrans %}</h4>


### PR DESCRIPTION
They have a specific way to search for tagged songs. The former link would just show songs called "LMMS", which excluded a lot of (usually higher production) songs.