### PR TITLE
Fix nightly downloads

### DIFF
--- a/lib/Artifacts.php
+++ b/lib/Artifacts.php
@@ -68,9 +68,16 @@ class Artifacts
 		return $this->mapPullRequestAssetsFromJson($validArtifacts, $id, $description);
 	}
 
-	public function getArtifactDownloadUrl(int $artifactId): string
+	public function getArtifactBinary(int $artifactId): string
 	{
 		return (string) $this->client->repo()->artifacts()->download($this->owner, $this->repo, $artifactId);
+	}
+
+	public function getArtifactName(int $artifactId): string
+	{
+		$artifact = $this->client->repo()->artifacts()->show($this->owner, $this->repo, $artifactId);
+		$release = 'g' . substr($artifact['workflow_run']['head_sha'], 0, 9);
+		return $this->repo . "-" . $artifact['name'] . "-" . $release . ".zip";
 	}
 
 	private function mapBranchAssetsFromJson(array $json): array

--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -7,6 +7,7 @@ use LMMS\Platform;
 use LMMS\Releases;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class DownloadController extends AbstractController
 {
@@ -80,7 +81,13 @@ class DownloadController extends AbstractController
     public function artifact(string $id, Artifacts $artifacts): Response
     {
         try {
-            return $this->redirect($artifacts->getArtifactDownloadUrl($id));
+            $response = new Response($artifacts->getArtifactBinary($id));
+            $disposition = HeaderUtils::makeDisposition(
+                HeaderUtils::DISPOSITION_ATTACHMENT,
+                $artifacts->getArtifactName($id)
+            );
+            $response->headers->set('Content-Disposition', $disposition);
+            return $response;
         } catch (\Exception $e) {
             if ($e->getCode() === 404) {
                 throw $this->createNotFoundException(previous: $e);


### PR DESCRIPTION
Recently the website stopped working with nightly downloads... The error suggests that something with the response header in symphony was wrong.

```
[Tue Sep 12 21:53:50 2023] [critical] Uncaught PHP Exception ErrorException: "Warning: Header may not contain NUL bytes" at /Users/owner/lmms.io/vendor/symfony/http-foundation/Response.php line 342
```

Investigation shows that `getArtifactDownloadURL(...)` calls `$this->client->repo()->artifacts()->download(...)` which returns the binary file (not the URL as the name might suggest) however, when Symphony casts this to a `Response`, the header is missing.  I'm not sure what recently changed to cause this, but crafting the `Response` object manually seems to fix this.

One upside of crafting a `Response` manually this way that it forces us to provide a filename, allowing the name to be more meaningful than `mingw32.zip`, etc.

Fixes https://github.com/LMMS/lmms/issues/6863

