### PR TITLE
Support downloading v4 artifacts

### DIFF
--- a/lib/Artifacts.php
+++ b/lib/Artifacts.php
@@ -2,6 +2,7 @@
 namespace LMMS;
 
 use Github\Client;
+use LMMS\HttpClientPlugin\UriRecordPlugin;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Artifacts
@@ -70,7 +71,8 @@ class Artifacts
 
 	public function getArtifactDownloadUrl(int $artifactId): string
 	{
-		return (string) $this->client->repo()->artifacts()->download($this->owner, $this->repo, $artifactId);
+		$this->client->repo()->artifacts()->download($this->owner, $this->repo, $artifactId);
+		return $this->client->getLastResponse()->getHeader(UriRecordPlugin::HEADER_NAME)[0];
 	}
 
 	private function mapBranchAssetsFromJson(array $json): array

--- a/lib/HttpClientPlugin/MethodPlugin.php
+++ b/lib/HttpClientPlugin/MethodPlugin.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LMMS\HttpClientPlugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Set the method for the request.
+ */
+class MethodPlugin implements Plugin
+{
+	public function __construct(private string $method)
+	{ }
+
+	public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+	{
+		return $next($request->withMethod($this->method));
+	}
+}

--- a/lib/HttpClientPlugin/UriRecordPlugin.php
+++ b/lib/HttpClientPlugin/UriRecordPlugin.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LMMS\HttpClientPlugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Store the request URI in a header on the response.
+ */
+class UriRecordPlugin implements Plugin
+{
+	public const HEADER_NAME = 'X-LMMS-Request-Uri';
+
+	public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+	{
+		$uri = (string) $request->getUri();
+
+		return $next($request)->then(function (ResponseInterface $response) use ($uri): ResponseInterface {
+			return $response->withHeader(self::HEADER_NAME, $uri);
+		});
+	}
+}


### PR DESCRIPTION
This PR allows downloading artifacts uploaded using version 4 of the `upload-artifact` action. See LMMS/lmms#7263.

We use a new technique for extracting the redirect location for artifact downloads. Previously, we searched for hardcoded strings within the host name of redirects, but this is the second time the host has changed and broken the downloads. Now, we follow the redirects as normal, and return the URL once we get a `200` response rather than a `302`. This is done with `HEAD` requests, in order to avoid actually downloading the artifact on the server.

Unfortunately, this breaks downloads for version 3 artifacts. The server for these responds with `200` as normal for `GET` requests to artifacts, but responds with `404` to `HEAD` requests for some reason. However, I hope this new approach will prove to be more robust against host changes in the future.

An additional change is made to avoid sending the GitHub API authorisation header to other servers. While the artifact server is accessible without authorisation, it will attempt to validate it if provided, and so responds with `403` when given a token intended for the API server. This change is better from a security standpoint too.

I also changed how the final download URL is returned from the API client. Instead of synthesising a fake response containing the URL, it is now put into a header and extracted from the most recent response object, which the client exposes. This seems to be more in line with how the client is supposed to be used, and is closer to how other libraries (particularly Guzzle) expose redirect history on response objects.

This change should be deployed at roughly the same time as LMMS/lmms#7263 is merged. Nightly downloads will then continue to work, and PR downloads will work as and when new builds are made for them. (Of course, artifacts can still be downloaded directly from GitHub if necessary.)