### PR TITLE
Add warning for missing 32 bit downloads for nightly

### DIFF
--- a/lib/Artifacts.php
+++ b/lib/Artifacts.php
@@ -112,6 +112,7 @@ class Artifacts
 			case 'macos': return Platform::MacOS;
 			case 'macos-arm64': return Platform::MacOS;
 			case 'macos-x86_64': return Platform::MacOS;
+			case 'mingw32': return Platform::Windows;
 			case 'mingw64': return Platform::Windows;
 			default: return Platform::Unknown;
 		}
@@ -124,6 +125,7 @@ class Artifacts
 			case 'macos': return 'macOS 10.15+';
 			case 'macos-arm64': return 'macOS (Apple Silicon)';
 			case 'macos-x86_64': return 'macOS (Intel)';
+			case 'mingw32': return 'Windows 32-bit';
 			case 'mingw64': return 'Windows 64-bit';
 			default: return 'Unknown (' . $artifactName . ')';
 		}

--- a/lib/Artifacts.php
+++ b/lib/Artifacts.php
@@ -112,7 +112,6 @@ class Artifacts
 			case 'macos': return Platform::MacOS;
 			case 'macos-arm64': return Platform::MacOS;
 			case 'macos-x86_64': return Platform::MacOS;
-			case 'mingw32': return Platform::Windows;
 			case 'mingw64': return Platform::Windows;
 			default: return Platform::Unknown;
 		}
@@ -125,7 +124,6 @@ class Artifacts
 			case 'macos': return 'macOS 10.15+';
 			case 'macos-arm64': return 'macOS (Apple Silicon)';
 			case 'macos-x86_64': return 'macOS (Intel)';
-			case 'mingw32': return 'Windows 32-bit';
 			case 'mingw64': return 'Windows 64-bit';
 			default: return 'Unknown (' . $artifactName . ')';
 		}

--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -67,7 +67,7 @@
 				<span class="fas fa-exclamation-circle"></span>
 				{% trans %}Downloads labeled Alpha, Beta, or Nightly are pre-release software, stability may suffer.{% endtrans %}
 			</small>
-			<br>Note: 32 bit nightly builds no longer available.
+			<br>{% trans %}Note: 32 bit nightly builds no longer available.{% endtrans %}
 		</div>
 	{% endif %}
 	{{ trailer|raw }}

--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -66,7 +66,7 @@
 			<small>
 				<span class="fas fa-exclamation-circle"></span>
 				{% trans %}Downloads labeled Alpha, Beta, or Nightly are pre-release software, stability may suffer.{% endtrans %}<br>
-				Note: 32 bit nigthly builds no longer available.
+				Note: 32 bit nightly builds no longer available.
 			</small>
 		</div>
 	{% endif %}

--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -65,7 +65,8 @@
 		<div id="prerelease" class="text-center">
 			<small>
 				<span class="fas fa-exclamation-circle"></span>
-				{% trans %}Downloads labeled Alpha, Beta, or Nightly are pre-release software, stability may suffer.{% endtrans %}
+				{% trans %}Downloads labeled Alpha, Beta, or Nightly are pre-release software, stability may suffer.{% endtrans %}<br>
+				Note: 32 bit nigthly builds no longer available.
 			</small>
 		</div>
 	{% endif %}

--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -65,9 +65,9 @@
 		<div id="prerelease" class="text-center">
 			<small>
 				<span class="fas fa-exclamation-circle"></span>
-				{% trans %}Downloads labeled Alpha, Beta, or Nightly are pre-release software, stability may suffer.{% endtrans %}<br>
-				Note: 32 bit nightly builds no longer available.
+				{% trans %}Downloads labeled Alpha, Beta, or Nightly are pre-release software, stability may suffer.{% endtrans %}
 			</small>
+			<br>Note: 32 bit nightly builds no longer available.
 		</div>
 	{% endif %}
 	{{ trailer|raw }}


### PR DESCRIPTION
I've started to remove 32 bit support in the CI. If this gets through, nightlies won't have 32 bit artefacts anymore for windows. There should be a warning to explain the missing artifacts. Per https://github.com/LMMS/lmms/issues/6614#issuecomment-2122841250 by @tresf 

TODO:
- [ ] Add translations. @liushuyu can you help?