### PR TITLE
Make the download button widths the same.

### DIFF
--- a/public/css/style.min.css
+++ b/public/css/style.min.css
@@ -158,6 +158,7 @@ td.lsp-file-info {
 }
 
 .btn-dl {
+  min-width: 16em;
   position: relative;
   padding: 0.5em;
   margin: 4px;
@@ -264,7 +265,6 @@ p.forum-stats {
   .container {
     width: 100%;
   }
-
   footer .container {
     width: inherit;
   }
@@ -379,10 +379,10 @@ a.btn {
 /* inner bottom border on hover over navbar items*/
 @media (min-width: 768px) {
   .navbar-custom .navbar-nav > li > a:hover,
-.navbar-custom .navbar-nav > .active > a,
-.navbar-custom .navbar-nav > .active > a:hover,
-.navbar-custom .navbar-nav > .open > a,
-.navbar-custom .navbar-nav > .open > a:hover {
+  .navbar-custom .navbar-nav > .active > a,
+  .navbar-custom .navbar-nav > .active > a:hover,
+  .navbar-custom .navbar-nav > .open > a,
+  .navbar-custom .navbar-nav > .open > a:hover {
     box-shadow: inset 0px -4px 0px 0px #373b37;
   }
   .navbar-custom .dropdown-menu {
@@ -395,7 +395,7 @@ a.btn {
     transition: visibility 0s, opacity 0.15s;
   }
   .navbar-custom .dropdown:hover .dropdown-menu,
-.navbar-custom .dropdown:focus .dropdown-menu {
+  .navbar-custom .dropdown:focus .dropdown-menu {
     visibility: visible;
     margin-top: 0;
     opacity: 1;
@@ -406,9 +406,9 @@ a.btn {
     background-image: none;
   }
   .navbar-custom .navbar-nav > li > a,
-.navbar-custom .navbar-nav > li > a:visited,
-.navbar-custom .navbar-nav > li > a:focus,
-.navbar-custom .navbar-nav .open .dropdown-menu {
+  .navbar-custom .navbar-nav > li > a:visited,
+  .navbar-custom .navbar-nav > li > a:focus,
+  .navbar-custom .navbar-nav .open .dropdown-menu {
     box-shadow: inset 0px -1px 0px 0px rgba(255, 255, 255, 0.1);
     background: inherit;
   }
@@ -538,7 +538,6 @@ div.error a:hover, div.error a:focus {
   div.jumbo {
     background-size: auto 55%, auto;
   }
-
   .jumbo div.header {
     margin-bottom: 80px;
   }
@@ -550,7 +549,6 @@ div.error a:hover, div.error a:focus {
     background-position: center;
     background-repeat: no-repeat;
   }
-
   .jumbo div.header {
     margin-bottom: 50px;
   }
@@ -631,21 +629,18 @@ a.social:hover, a.social:focus {
     height: 356px;
     background: none;
   }
-
   .video-front,
-.video-bg {
+  .video-bg {
     height: 100%;
     width: 100%;
     position: absolute;
     top: 0;
     left: 0;
   }
-
   .video-front {
     padding: 45px 0 70px 0;
     background: url("../img/videopattern.png");
   }
-
   .video-bg {
     overflow: hidden;
   }
@@ -655,7 +650,6 @@ a.social:hover, a.social:focus {
     width: auto;
     height: auto;
   }
-
   .modal-custom .modal-dialog {
     margin-top: 60px;
     width: 800px;

--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -183,6 +183,7 @@ td.lsp-file-info {
 }
 
 .btn-dl {
+	min-width: 16em;
 	position: relative;
 	padding: 0.5em;
 	margin: 4px;


### PR DESCRIPTION
Previously, the download buttons looked like this:
![image](https://github.com/user-attachments/assets/b7ea53ea-3cb2-477e-ba76-cb9231ded0b4)
but the unnevenness of the download button annoyed me so i made it look like this:
![image](https://github.com/user-attachments/assets/eecfa351-47bf-4b0f-b2da-8f959172dd45)

I seriously don't understand why the style.scss diff is so large, all i did was add one line (186).