### PR TITLE
Add Windows setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,20 @@ You'll have to run this command every time the dependencies in `composer.json` c
 
 ### Windows
 
-A convenient setup script is provided in `dev/windows/setup.ps1`. You just need to provide the path of where you've installed PHP, and it will install Composer and the project's dependencies on its own.
+A convenient setup script is provided in `dev/windows/setup.ps1`. You just need to provide the path of where you've installed PHP, and it will setup PHP, install Composer, and install the project's dependencies on its own.
 
-If you've manually installed PHP without the use of other PHP-dependent software like WAMP (such as directly downloading and unzipping the binary from the PHP website), *and the automated install script is failing*, there are some changes you'll need to make to your `php.ini`:
+If you skipped automatic `.ini` validation or modification, there are some changes you'll need to make to your configuration file manually:
 
-1. Locate `php.ini-development` in the folder where you've installed/extracted the PHP release. This folder should also be where `php.exe` resides
-2. Remove the `-development` suffix from the file extension, the resulting file name should just be `php.ini`
-3. Edit the file, and uncomment these lines:
+1. Locate `php.ini-development` or `php.ini` in the folder where you've installed/extracted the PHP release. This folder should also be where `php.exe` resides
+   * If you have the `php.ini-development` file, remove the `-development` suffix from the file extension, the resulting file name should just be `php.ini`
+   * If you would like to just edit your existing `php.ini`, leave it be.
+2. Edit the file, and uncomment these lines:
    1. `;extension_dir = "ext"`
    2. `;extension=gd`
    3. `;extension=intl`
    4. `;extension=openssl`
    5. `;extension=pdo_mysql`
-4. Save your edits, then re-run the setup script.
+3. Save your edits, then re-run the setup script.
 
 Not only does this allow the automatic script to execute, but also enable the local development server to function at all.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains the source for LMMS's website, live at <https://lmms.io
 
 ## How to test the website locally
 
+### Linux
+
 1. Fork the repository [here](https://github.com/LMMS/lmms.io/fork)
 2. Clone the forked repository.
 
@@ -14,7 +16,7 @@ git clone https://github.com/<your-username>/lmms.io.git
 3. Get Composer
 
 This project uses [Composer](http://getcomposer.org) for dependency management. You'll have to fetch those dependencies using Composer. For this, you must have Composer installed on your system. For quickly installing Composer locally on *nix, run:
-	
+
 Install PHP 8.2 and the required components.\
 These commands are for Linux. It may be different from how it is installed on other OSes.
 
@@ -22,33 +24,46 @@ These commands are for Linux. It may be different from how it is installed on ot
 sudo add-apt-repository ppa:ondrej/php
 sudo apt install curl php8.2 php8.2-xml php8.2-gd php8.2-intl php-symfony
 ```
-	
+
 ```bash
 cd lmms.io
 curl -sS https://getcomposer.org/installer | php
 ```
 
-For installing Composer locally on Windows (i.e. Wamp), run:
-
-```bash
-cd lmms.io
-php -r "eval('?>'.file_get_contents('https://getcomposer.org/installer'));"
-```
-
 > **Note:**
 > You need to add `php.exe` to the Windows PATH, usually located in `c:\wamp\bin\php\phpx.y.z`
 > For instructions for other OSes or for installing globally, visit Composer's [Getting Started](https://getcomposer.org/doc/00-intro.md) document.
-   
+
 1. Fetch dependencies using Composer.
 
 After downloading Composer locally using the instructions above, fetch the dependencies by running the command below.
-   
+
 ```bash
 php composer.phar install
 ```
-   
+
 You'll have to run this command every time the dependencies in `composer.json` change.
-	
+
+### Windows
+
+A convenient setup script is provided in `dev/windows/setup.ps1`. You just need to provide the path of where you've installed PHP, and it will install Composer and the project's dependencies on its own.
+
+If you've manually installed PHP without the use of other PHP-dependent software like WAMP (such as directly downloading and unzipping the binary from the PHP website), *and the automated install script is failing*, there are some changes you'll need to make to your `php.ini`:
+
+1. Locate `php.ini-development` in the folder where you've installed/extracted the PHP release. This folder should also be where `php.exe` resides
+2. Remove the `-development` suffix from the file extension, the resulting file name should just be `php.ini`
+3. Edit the file, and uncomment these lines:
+   1. `;extension_dir = "ext"`
+   2. `;extension=gd`
+   3. `;extension=intl`
+   4. `;extension=openssl`
+   5. `;extension=pdo_mysql`
+4. Save your edits, then re-run the setup script.
+
+Not only does this allow the automatic script to execute, but also enable the local development server to function at all.
+
+### macOS
+
 > **Note**:
 > For macOS, some dependencies must be [installed manually](https://superuser.com/a/1359317/443147).
 
@@ -57,25 +72,25 @@ You'll have to run this command every time the dependencies in `composer.json` c
 ```bash
 php -S localhost:8000 -t ./public/
 ```
-	
+
 You can then open <http://localhost:8000/> in a browser.
-	
+
 1. Optionally, configure the local `apache` and `nginx` instances.
-	
+
 With Apache:
 
 ```xml
-	<Directory /home/user/lmms.io/public/>
-		# add fallback resource to Apache config
-		FallbackResource /index.php
-	</Directory>
+ <Directory /home/user/lmms.io/public/>
+  # add fallback resource to Apache config
+  FallbackResource /index.php
+ </Directory>
 ```
-	
+
 With Nginx:
 
 ```nginx
-	# go to our front controller if none of them exists
-	location / {
-		try_files $uri $uri/ /index.php?$args;
-	}
+ # go to our front controller if none of them exists
+ location / {
+  try_files $uri $uri/ /index.php?$args;
+ }
 ```

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -28,6 +28,8 @@ elseif ([string]::IsNullOrEmpty($phpDir)) {
 
 Write-Host -ForegroundColor Gray "[setup] Using $fullPhpDir as PHP runner"
 
+$rootDir = Split-Path -Path (Split-Path -Path $PSScriptRoot)
+
 function Validate-Ini {
   Write-Host "[setup] Validating .ini file"
 
@@ -132,14 +134,12 @@ Validate-Ini
 
 function Setup-Composer {
   # shift to root dir
-  if ($pwd -match "(\\dev\\windows)") {
-    Set-Location "../../"
-  }
+  Set-Location $rootDir
 
   # download composer
   Write-Host "[setup] Dowloading composer's installer"
   $composerInstallerUrl = "https://getcomposer.org/installer"
-  $composerInstallerPath = Join-Path $pwd "composer-setup.php"
+  $composerInstallerPath = Join-Path $rootDir "composer-setup.php"
   Invoke-WebRequest -Uri $composerInstallerUrl -OutFile $composerInstallerPath
 
   # check if composer's installer exists
@@ -161,4 +161,3 @@ function Setup-Composer {
 Setup-Composer
 
 Write-Host -ForegroundColor Green "[setup] Setup complete! Run 'php -S localhost:8000 -t ./public/' to start the local dev server"
-

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -1,4 +1,13 @@
-$phpDir = Read-Host "Enter the path of your PHP installation (e.g. 'C:\Program Files\php', 'D:\php', 'C:\wamp\bin\php')"
+param (
+  [Alias("PSPath")]
+  [string] $phpDir
+)
+
+# check if the script param is empty
+if ([string]::IsNullOrEmpty($phpDir)) {
+  $phpDir = Read-Host "Enter the path of your PHP installation (e.g. 'C:\Program Files\php', 'D:\php', 'C:\wamp\bin\php')"
+}
+
 $fullPhpDir = Join-Path $phpDir "php.exe"
 
 # check if path exists

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -24,15 +24,7 @@ Write-Host "Using $fullPhpDir as PHP runner."
 
 
 function Validate-Ini {
-  $confirm = Read-Host "Would you like for the script to validate your PHP`'s .ini file? [y/n]"
-
-  if ($confirm -match "n") {
-    Write-Host -ForegroundColor Yellow "Skipping .ini file validation. If the setup script fails further down the line, you can re-run the setup script and say 'y' on .ini validation, or refer to the README on how to enable the particular settings needed"
-    return
-  }
-  else {
-    Write-Host "Validating .ini file"
-  }
+  Write-Host "Validating .ini file"
 
   $iniSettings = @(
     ";extension_dir = `"ext`""

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -1,0 +1,36 @@
+$phpDir = Read-Host "Enter the path of your PHP installation (e.g. 'C:\Program Files\php', 'D:\php', 'C:\wamp\bin\php')"
+$fullPhpDir = Join-Path $phpDir "php.exe"
+
+# check if path exists
+if (-Not (Test-Path $phpDir)) {
+  throw "The directory '$phpDir' does not exist. Did you point to the exact file instead of the containing folder?"
+}
+
+# check if php.exe is there
+if (-Not (Test-Path $fullPhpDir)) {
+  Write-Error "'php.exe' was not found in '$phpDir'. Was it installed correctly?"
+  exit 1
+}
+
+# shift to root dir
+if ($pwd -match "(\\dev\\windows)") {
+  Set-Location "../../"
+}
+
+# download composer
+$composerInstallerUrl = "https://getcomposer.org/installer"
+$composerInstallerPath = Join-Path $pwd "composer-setup.php"
+Invoke-WebRequest -Uri $composerInstallerUrl -OutFile $composerInstallerPath
+
+# check if composer's installer exists
+if (-Not (Test-Path $composerInstallerPath)) {
+  Write-Error "Failed to download Composer installer"
+  exit 1
+}
+
+Start-Process -FilePath $fullPhpDir -ArgumentList $composerInstallerPath -Wait -NoNewWindow
+
+Start-Process -FilePath $fullPhpDir -ArgumentList "composer.phar install" -Wait -NoNewWindow
+
+# cleanup composer's installer
+Remove-Item $composerInstallerPath

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -20,11 +20,11 @@ if (-Not (Test-Path $fullPhpDir)) {
   throw "'php.exe' was not found in '$phpDir'. Was it installed correctly?"
 }
 
-Write-Host "Using $fullPhpDir as PHP runner."
+Write-Host "[setup] Using $fullPhpDir as PHP runner."
 
 
 function Validate-Ini {
-  Write-Host "Validating .ini file"
+  Write-Host "[setup] Validating .ini file"
 
   $iniSettings = @(
     ";extension_dir = `"ext`""
@@ -41,7 +41,7 @@ function Validate-Ini {
     $confirm = Read-Host "You do not have a 'php.ini' file, but you have the 'php.ini-development' file. Would you like the script to enable the development .ini? Saying [n] will exit the script [y/n]"
 
     if ($confirm -match "y") {
-      Write-Host "Renaming 'php.ini-development' to 'php.ini'"
+      Write-Host "[setup] Renaming 'php.ini-development' to 'php.ini'"
       Rename-Item -Path $iniFileDevPath -NewName "php.ini"
     }
     else {
@@ -66,7 +66,7 @@ function Validate-Ini {
     $confirm = Read-Host "Your .ini file is not suitable for running the local test environment. Would you like the script to modify the file and enable the relevant settings? The script will only modify the settings needed for the project to run and leave others unchanged, you can view the list of settings that needs to be enabled in the root README [y/n]"
 
     if ($confirm -match "y") {
-      Write-Host "Modifying and writing settings"
+      Write-Host "[setup] Modifying and writing settings"
 
       $iniFileNew = ""
       foreach ($iniLine in $iniFile) {
@@ -83,22 +83,22 @@ function Validate-Ini {
         }
       }
 
-      Write-Host -ForegroundColor Green "Settings file modified"
+      Write-Host -ForegroundColor Green "[setup] Settings file modified"
 
       Clear-Content -Path $iniFilePath
       foreach ($line in $iniFileNew) {
         Add-Content -Path $iniFilePath -Value $line
       }
 
-      Write-Host -ForegroundColor Green "Your .ini settings are valid, continuing script"
+      Write-Host -ForegroundColor Green "[setup] Your .ini settings are valid, continuing script"
     }
     else {
-      Write-Host -ForegroundColor Yellow "Skipping .ini file modification. You must enable the relevant settings by yourself. Refer to the README for instructions on how to enable the settings manually."
-      Write-Host -ForegroundColor Red "There's a chance that the script will error after this"
+      Write-Host -ForegroundColor Yellow "[setup] Skipping .ini file modification. You must enable the relevant settings by yourself. Refer to the README for instructions on how to enable the settings manually."
+      Write-Host -ForegroundColor Red "[setup] There's a chance that the script will error after this"
     }
   }
   else {
-    Write-Host -ForegroundColor Green "All settings are valid, continuing setup"
+    Write-Host -ForegroundColor Green "[setup] All settings are valid, continuing setup"
   }
 }
 
@@ -110,7 +110,7 @@ if ($pwd -match "(\\dev\\windows)") {
 }
 
 # download composer
-Write-Host "Dowloading composer's installer"
+Write-Host "[setup] Dowloading composer's installer"
 $composerInstallerUrl = "https://getcomposer.org/installer"
 $composerInstallerPath = Join-Path $pwd "composer-setup.php"
 Invoke-WebRequest -Uri $composerInstallerUrl -OutFile $composerInstallerPath
@@ -120,14 +120,14 @@ if (-Not (Test-Path $composerInstallerPath)) {
   throw "Failed to download Composer installer"
 }
 
-Write-Host "Installing composer"
+Write-Host "[setup] Installing composer"
 Start-Process -FilePath $fullPhpDir -ArgumentList $composerInstallerPath -Wait -NoNewWindow
 
-Write-Host "Getting dependencies"
+Write-Host "[setup] Getting dependencies"
 Start-Process -FilePath $fullPhpDir -ArgumentList "composer.phar install" -Wait -NoNewWindow
 
 # cleanup composer's installer
-Write-Host "Cleaning up composer's installer"
+Write-Host "[setup] Cleaning up composer's installer"
 Remove-Item $composerInstallerPath
 
-Write-Host -ForegroundColor Green "Setup complete! Run 'php -S localhost:8000 -t ./public/' to start the local dev server"
+Write-Host -ForegroundColor Green "[setup] Setup complete! Run 'php -S localhost:8000 -t ./public/' to start the local dev server"

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -1,27 +1,31 @@
 param (
-  [Alias("PSPath")]
+  [ValidateScript({ Test-Path $_ })]
   [string] $phpDir
 )
 
-# check if the script param is empty
-if ([string]::IsNullOrEmpty($phpDir)) {
+# check if php exists in Path, then set it as full PHP dir
+if (-not [string]::IsNullOrEmpty((Get-Command php).Source)) {
+  $phpDir = Split-Path (Get-Command php).Source
+  $fullPhpDir = (Get-Command php).Source
+}
+# if not, then check if the phpDir arg exists
+elseif ([string]::IsNullOrEmpty($phpDir)) {
   $phpDir = Read-Host "Enter the path of your PHP installation (e.g. 'C:\Program Files\php', 'D:\php', 'C:\wamp\bin\php')"
-}
 
-$fullPhpDir = Join-Path $phpDir "php.exe"
+  # check if given path exists
+  if (-not (Test-Path $phpDir)) {
+    throw "The directory '$phpDir' does not exist. Did you point to the exact file instead of the containing folder?"
+  }
 
-# check if path exists
-if (-Not (Test-Path $phpDir)) {
-  throw "The directory '$phpDir' does not exist. Did you point to the exact file instead of the containing folder?"
-}
+  $fullPhpDir = Join-Path $phpDir "php.exe"
 
-# check if php.exe is there
-if (-Not (Test-Path $fullPhpDir)) {
-  throw "'php.exe' was not found in '$phpDir'. Was it installed correctly?"
+  # check if php.exe is there
+  if (-not (Test-Path $fullPhpDir)) {
+    throw "'php.exe' was not found in '$phpDir'. Was it installed correctly?"
+  }
 }
 
 Write-Host "[setup] Using $fullPhpDir as PHP runner."
-
 
 function Validate-Ini {
   Write-Host "[setup] Validating .ini file"

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -122,31 +122,36 @@ function Validate-Ini {
 
 Validate-Ini
 
-# shift to root dir
-if ($pwd -match "(\\dev\\windows)") {
-  Set-Location "../../"
+
+function Setup-Composer {
+  # shift to root dir
+  if ($pwd -match "(\\dev\\windows)") {
+    Set-Location "../../"
+  }
+
+  # download composer
+  Write-Host "[setup] Dowloading composer's installer"
+  $composerInstallerUrl = "https://getcomposer.org/installer"
+  $composerInstallerPath = Join-Path $pwd "composer-setup.php"
+  Invoke-WebRequest -Uri $composerInstallerUrl -OutFile $composerInstallerPath
+
+  # check if composer's installer exists
+  if (-Not (Test-Path $composerInstallerPath)) {
+    throw "Failed to download Composer installer"
+  }
+
+  Write-Host "[setup] Installing composer"
+  Start-Process -FilePath $fullPhpDir -ArgumentList $composerInstallerPath -Wait -NoNewWindow
+
+  Write-Host "[setup] Getting dependencies"
+  Start-Process -FilePath $fullPhpDir -ArgumentList "composer.phar install" -Wait -NoNewWindow
+
+  # cleanup composer's installer
+  Write-Host "[setup] Cleaning up composer's installer"
+  Remove-Item $composerInstallerPath
 }
 
-# download composer
-Write-Host "[setup] Dowloading composer's installer"
-$composerInstallerUrl = "https://getcomposer.org/installer"
-$composerInstallerPath = Join-Path $pwd "composer-setup.php"
-Invoke-WebRequest -Uri $composerInstallerUrl -OutFile $composerInstallerPath
-
-# check if composer's installer exists
-if (-Not (Test-Path $composerInstallerPath)) {
-  throw "Failed to download Composer installer"
-}
-
-Write-Host "[setup] Installing composer"
-Start-Process -FilePath $fullPhpDir -ArgumentList $composerInstallerPath -Wait -NoNewWindow
-
-Write-Host "[setup] Getting dependencies"
-Start-Process -FilePath $fullPhpDir -ArgumentList "composer.phar install" -Wait -NoNewWindow
-
-# cleanup composer's installer
-Write-Host "[setup] Cleaning up composer's installer"
-Remove-Item $composerInstallerPath
+Setup-Composer
 
 Write-Host -ForegroundColor Green "[setup] Setup complete! Run 'php -S localhost:8000 -t ./public/' to start the local dev server"
 

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -8,8 +8,7 @@ if (-Not (Test-Path $phpDir)) {
 
 # check if php.exe is there
 if (-Not (Test-Path $fullPhpDir)) {
-  Write-Error "'php.exe' was not found in '$phpDir'. Was it installed correctly?"
-  exit 1
+  throw "'php.exe' was not found in '$phpDir'. Was it installed correctly?"
 }
 
 # shift to root dir
@@ -24,8 +23,7 @@ Invoke-WebRequest -Uri $composerInstallerUrl -OutFile $composerInstallerPath
 
 # check if composer's installer exists
 if (-Not (Test-Path $composerInstallerPath)) {
-  Write-Error "Failed to download Composer installer"
-  exit 1
+  throw "Failed to download Composer installer"
 }
 
 Start-Process -FilePath $fullPhpDir -ArgumentList $composerInstallerPath -Wait -NoNewWindow

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -20,12 +20,92 @@ if (-Not (Test-Path $fullPhpDir)) {
   throw "'php.exe' was not found in '$phpDir'. Was it installed correctly?"
 }
 
+Write-Host "Using $fullPhpDir as PHP runner."
+
+
+function Validate-Ini {
+  $confirm = Read-Host "Would you like for the script to validate your PHP`'s .ini file? [y/n]"
+
+  if ($confirm -match "n") {
+    Write-Host -ForegroundColor Yellow "Skipping .ini file validation. If the setup script fails further down the line, you can re-run the setup script and say 'y' on .ini validation, or refer to the README on how to enable the particular settings needed"
+    return
+  }
+
+  Write-Host "Validating .ini file"
+
+  $iniSettings = @(
+    ";extension_dir = `"ext`""
+    ";extension=gd"
+    ";extension=intl"
+    ";extension=openssl"
+    ";extension=pdo_mysql"
+  )
+  $iniValid = $true
+
+  $iniFilePath = Join-Path $phpDir "php.ini"
+  $iniFileDevPath = Join-Path $phpDir "php.ini-development"
+  if (-not (Test-Path $iniFilePath) -and (Test-Path $iniFileDevPath)) {
+    $confirm = Read-Host "You do not have a 'php.ini' file, but you have the 'php.ini-development' file. Would you like the script to enable the development .ini? Saying [n] will exit the script [y/n]"
+
+    if ($confirm -match "y") {
+      Write-Host "Renaming 'php.ini-development' to 'php.ini'"
+      Rename-Item -Path $iniFileDevPath -NewName "php.ini"
+    }
+    else {
+      throw "Exiting since the script must use 'php.ini'. You must rename/create the file yourself"
+    }
+  }
+  elseif (-not (Test-Path $iniFilePath) -and -not (Test-Path $iniFileDevPath)) {
+    throw "'php.ini' and 'php.ini-development' cannot be found. Was PHP installed correctly?"
+  }
+
+  $iniFile = Get-Content $iniFilePath
+
+  foreach ($line in $iniFile) {
+    foreach ($setting in $iniSettings) {
+      if ($line -match $setting) {
+        $iniValid = $false
+      }
+    }
+  }
+
+  if ($iniValid -eq $false) {
+    $confirm = Read-Host "Your .ini file is not suitable for running the local test environment. Would you like the script to modify the file and enable the relevant settings? The script will only modify the settings needed for the project to run and leave others unchanged, you can view the list of settings that needs to be enabled in the root README [y/n]"
+
+    if ($confirm -match "y") {
+      Write-Host "Modifying and writing settings"
+
+      foreach ($line in $iniFile) {
+        foreach ($setting in $iniSettings) {
+          if ($line -match $setting) {
+            $line = $line.Replace(";", "")
+          }
+        }
+      }
+
+      Clear-Content -Path $iniFilePath
+      foreach ($line in $iniFile) {
+        Add-Content -Path $iniFilePath -Value $line
+        Write-Host -ForegroundColor Yellow "Skipping .ini file modification. You must enable the relevant settings by yourself. Refer to the README for instructions on how to enable the settings manually."
+      }
+      else {
+        Write-Host -ForegroundColor Yellow "Skipping .ini file modification. You must enable the relevant settings by yourself"
+      }
+    }
+  } else {
+    Write-Host -ForegroundColor Green "Your .ini settings are valid, continuing script"
+  }
+}
+
+Validate-Ini
+
 # shift to root dir
 if ($pwd -match "(\\dev\\windows)") {
   Set-Location "../../"
 }
 
 # download composer
+Write-Host "Dowloading composer's installer"
 $composerInstallerUrl = "https://getcomposer.org/installer"
 $composerInstallerPath = Join-Path $pwd "composer-setup.php"
 Invoke-WebRequest -Uri $composerInstallerUrl -OutFile $composerInstallerPath
@@ -35,9 +115,12 @@ if (-Not (Test-Path $composerInstallerPath)) {
   throw "Failed to download Composer installer"
 }
 
+Write-Host "Installing composer"
 Start-Process -FilePath $fullPhpDir -ArgumentList $composerInstallerPath -Wait -NoNewWindow
 
+Write-Host "Getting dependencies"
 Start-Process -FilePath $fullPhpDir -ArgumentList "composer.phar install" -Wait -NoNewWindow
 
 # cleanup composer's installer
+Write-Host "Cleaning up composer's installer"
 Remove-Item $composerInstallerPath


### PR DESCRIPTION
This PR (which now uses the correct base branch) adds a Windows-specific setup script located in `dev/windows/setup.ps1` using PowerShell.

The script's actions is as follows:
1. Create the variables `$phpDir` and `$fullPhpDir`
2. Asks for the PHP install directory, because it isn't standardized in Windows
3. Checks if the given path exists
4. Checks if the PHP executable exists
5. If the script was started in the `dev/windows` folder, go to the project root
6. Create the variables `$composerInstallerUrl` and `$composerInstallerPath`
7. Downloads composer's installer using the two variables aforementioned
8. Checks if composer exists after the download
9. Runs composer's installer using the PHP in `$fullPhpDir`
10. Runs the `install` command from composer to install dependencies
11. Cleans up the downloaded installer