### PR TITLE
Update download button colors to match lmms/#5166

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -25,11 +25,11 @@
   --fg-code-dark: color-mix(in oklch, var(--fg-code), white 25%);
   --bg-btn: #fafafa;
   --bg-btn-dark: hsl(0, 0%, 2%);
-  --bg-btn-dl-stable: #337ab7;
+  --bg-btn-dl-stable: oklch(65% 0.15 152);
   --bg-btn-dl-stable-dark: color-mix(in oklch, var(--bg-btn-dl-stable), black);
-  --bg-btn-dl-alpha: #f0ad4e;
+  --bg-btn-dl-alpha: oklch(60% 0.15 250);
   --bg-btn-dl-alpha-dark: color-mix(in oklch, var(--bg-btn-dl-alpha), black);
-  --bg-btn-dl-nightly: #7871c5;
+  --bg-btn-dl-nightly: oklch(55% 0.22 290);
   --bg-btn-dl-nightly-dark: color-mix(in oklch, var(--bg-btn-dl-nightly), black);
   --bg-well: #f5f5f5;
   --bg-well-dark: hsl(0, 0%, 4%);
@@ -221,50 +221,48 @@ td.lsp-file-info {
 
 /* download button bg colors */
 .btn-dl {
-  &:hover {
-    color: #fff;
-    filter: brightness(1.1);
-  }
-
-  &.btn-primary {
-    background-color: light-dark(var(--bg-btn-dl-stable), var(--bg-btn-dl-stable-dark));
-    border: 1px solid var(--bg-btn-dl-stable);
-  }
-
-  &.btn-warning {
-    background-color: light-dark(var(--bg-btn-dl-alpha), var(--bg-btn-dl-alpha-dark));
-    border: 1px solid var(--bg-btn-dl-alpha);
-  }
-
-  &.btn-secondary {
-    background-color: light-dark(var(--bg-btn-dl-nightly), var(--bg-btn-dl-nightly-dark));
-    border: 1px solid var(--bg-btn-dl-nightly);
-  }
-}
-
-.btn-dl {
   min-width: 16em;
   position: relative;
   margin: 4px;
   text-align: left;
   padding: 1em 1em 1em 5em;
-}
 
-.btn-dl .small {
-  position: relative;
-  font-size: 0.9em;
-}
+  &:hover {
+    color: #fff;
+    filter: brightness(1.1);
+  }
 
-.btn-dl .big {
-  font-size: 1.2em;
-}
+  &.btn-dl-stable {
+    background-color: light-dark(var(--bg-btn-dl-stable), var(--bg-btn-dl-stable-dark));
+    border: 1px solid var(--bg-btn-dl-stable);
+  }
 
-.btn-dl .download-icon {
-  display: block;
-  position: absolute;
-  left: 0.2em;
-  top: 0.3em;
-  opacity: 0.9;
+  &.btn-btn-dl-alpha {
+    background-color: light-dark(var(--bg-btn-dl-alpha), var(--bg-btn-dl-alpha-dark));
+    border: 1px solid var(--bg-btn-dl-alpha);
+  }
+
+  &.btn-dl-nightly {
+    background-color: light-dark(var(--bg-btn-dl-nightly), var(--bg-btn-dl-nightly-dark));
+    border: 1px solid var(--bg-btn-dl-nightly);
+  }
+
+  &.small {
+    position: relative;
+    font-size: 0.9em;
+  }
+
+  &.big {
+    font-size: 1.2em;
+  }
+
+  &.download-icon {
+    display: block;
+    position: absolute;
+    left: 0.2em;
+    top: 0.3em;
+    opacity: 0.9;
+  }
 }
 
 /* Prevent cutting off of images on narrow devices*/

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -29,8 +29,10 @@
   --bg-btn-dl-stable-dark: color-mix(in oklch, var(--bg-btn-dl-stable), black);
   --bg-btn-dl-alpha: oklch(60% 0.15 250);
   --bg-btn-dl-alpha-dark: color-mix(in oklch, var(--bg-btn-dl-alpha), black);
-  --bg-btn-dl-nightly: oklch(55% 0.22 290);
+  --bg-btn-dl-nightly: oklch(56% 0.2 290);
   --bg-btn-dl-nightly-dark: color-mix(in oklch, var(--bg-btn-dl-nightly), black);
+  --bg-btn-dl-pr: oklch(72% 0.15 75);
+  --bg-btn-dl-pr-dark: color-mix(in oklch, var(--bg-btn-dl-pr), black);
   --bg-well: #f5f5f5;
   --bg-well-dark: hsl(0, 0%, 4%);
   --col-anchor: #337ab7;
@@ -228,7 +230,6 @@ td.lsp-file-info {
   padding: 1em 1em 1em 5em;
 
   &:hover {
-    color: #fff;
     filter: brightness(1.1);
   }
 
@@ -245,6 +246,11 @@ td.lsp-file-info {
   &.btn-dl-nightly {
     background-color: light-dark(var(--bg-btn-dl-nightly), var(--bg-btn-dl-nightly-dark));
     border: 1px solid var(--bg-btn-dl-nightly);
+  }
+
+  &.btn-dl-pr {
+    background-color: light-dark(var(--bg-btn-dl-pr), var(--bg-btn-dl-pr-dark));
+    border: 1px solid var(--bg-btn-dl-pr);
   }
 
   &.small {

--- a/templates/download/index.twig
+++ b/templates/download/index.twig
@@ -3,7 +3,7 @@
 {% import _self as download %}
 
 {# Macro for printing oversized download buttons #}
-{% macro printrelbutton(rel, btnclass = 'btn-primary') %}
+{% macro printrelbutton(rel, btnclass = 'btn-dl-stable') %}
 	{% if rel != null %}
 		<a class="btn btn-lg btn-dl {{ btnclass }}" href="{{ rel.downloadUrl }}">
 			<span class="fas fa-cloud-download-alt fa-3x download-icon"></span>
@@ -51,14 +51,14 @@
 		{% endif %}
 		</h3>
 		{% for asset in pre %}
-			{{ download.printrelbutton(asset, 'btn-warning') }}
+			{{ download.printrelbutton(asset, 'btn-dl-alpha') }}
 		{% endfor %}
 		{{ download.releasenotes(pre[0].description, "#{os}-pre") }}
 	{% endif %}
 	{% if nightly %}
 		<h3>{% trans %}Nightly Versions{% endtrans %}</h3>
 		{% for asset in nightly %}
-			{{ download.printrelbutton(asset, 'btn-secondary') }}
+			{{ download.printrelbutton(asset, 'btn-dl-nightly') }}
 		{% endfor %}
 	{% endif %}
 	{% if pre or nightly %}

--- a/templates/download/linux.twig
+++ b/templates/download/linux.twig
@@ -51,7 +51,7 @@
 			<p>{% trans %}For installing LMMS on Debian based distributions such as Debian itself, Ubuntu or Linux Mint, just click the button below.{% endtrans %}<br></p>
 			<!-- <p><a class="btn btn-primary" target="new" href="apt://lmms"><span class="fas fa-download"></span> Install LMMS</a></p> -->
 			<p>
-			<a class="btn btn-md btn-dl btn-primary" href="apt://lmms" title="apt://lmms">
+			<a class="btn btn-md btn-dl btn-dl-stable" href="apt://lmms" title="apt://lmms">
 				<span class="fas fa-cloud-download-alt fa-3x download-icon"></span>
 				<span class="big">{% trans %}Install LMMS now{% endtrans %}</span><br>
 				<span class="small">{% trans %}From your package manager{% endtrans %}</span>

--- a/templates/download/pull-request.twig
+++ b/templates/download/pull-request.twig
@@ -13,7 +13,7 @@
 		</div>
 		<h3>{% trans %}Pull Request {% endtrans %} <a href="https://github.com/lmms/lmms/pull/{{ id }}">#{{ id }}</a></h3>
 		{% for asset in artifacts %}
-			{{ download.printrelbutton(asset, 'btn-secondary') }}
+			{{ download.printrelbutton(asset, 'btn-dl-pr') }}
 		{% endfor %}
 		{{ download.releasenotes(artifacts[0].description, "#{os}-artifacts") }}
 		{% if instruction %}<div class="alert alert-warning">{{ instruction|raw }}</div>{% endif %}


### PR DESCRIPTION
Resolves #404 (lol) by updating download button colors to match https://github.com/LMMS/lmms/pull/5166. The colors used here are defined in the OKLCH color space and have their brightness and saturation adjusted to look mostly consistent.

```css
--bg-btn-dl-stable:  oklch(65% 0.15 152);
--bg-btn-dl-alpha:   oklch(60% 0.15 250);
--bg-btn-dl-nightly: oklch(56% 0.2  290);
--bg-btn-dl-pr:      oklch(72% 0.15  75);
```
![image](https://github.com/user-attachments/assets/8e35ad0e-5029-4ab3-9f4a-2ddfc9deeb62)
![image](https://github.com/user-attachments/assets/6d4eb31d-3a77-4074-bf2f-d5f4516af6b3)
![image](https://github.com/user-attachments/assets/d7eb3484-adde-4fe4-8246-09a1b580fdaa)
![image](https://github.com/user-attachments/assets/1608674d-76a0-4744-ade8-c05a61da458c)
![image](https://github.com/user-attachments/assets/f06a4872-1f3f-4027-9427-2d5b4b328ae9)
![image](https://github.com/user-attachments/assets/31f23674-6942-4eed-b283-afdded7635aa)
![image](https://github.com/user-attachments/assets/ed028227-6eaa-4aac-a540-37e8fa3fb6bb)
![image](https://github.com/user-attachments/assets/77f3e183-0162-4452-9f7c-4439b1a6a669)


This PR also cleans up the `.btn-dl` family of rules a bit.