### PR TITLE
Fix my crimes against download buttons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -230,6 +230,7 @@ td.lsp-file-info {
   padding: 1em 1em 1em 5em;
 
   &:hover {
+    color: #fff;
     filter: brightness(1.1);
   }
 
@@ -238,7 +239,7 @@ td.lsp-file-info {
     border: 1px solid var(--bg-btn-dl-stable);
   }
 
-  &.btn-btn-dl-alpha {
+  &.btn-dl-alpha {
     background-color: light-dark(var(--bg-btn-dl-alpha), var(--bg-btn-dl-alpha-dark));
     border: 1px solid var(--bg-btn-dl-alpha);
   }
@@ -253,16 +254,16 @@ td.lsp-file-info {
     border: 1px solid var(--bg-btn-dl-pr);
   }
 
-  &.small {
+  & .small {
     position: relative;
     font-size: 0.9em;
   }
 
-  &.big {
+  & .big {
     font-size: 1.2em;
   }
 
-  &.download-icon {
+  & .download-icon {
     display: block;
     position: absolute;
     left: 0.2em;


### PR DESCRIPTION
I broke download buttons in #405 due to a few typos. This would have been caught with a nonzero amount of testing beyond screwing around in inspect element, so that's on me. This PR should restore the shapes of the download buttons as well as make the alpha buttons use their colors properly.

![image](https://github.com/user-attachments/assets/b179e4d0-7ed2-4597-ba1a-02bfece42aeb)
![image](https://github.com/user-attachments/assets/8eb02577-b594-4272-b16a-2a109861ece3)
