### PR TITLE
add theming compatibility for older browsers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -30,13 +30,14 @@
 
   --fg-segment: var(--fg);
   --fg-segment-dark: var(--fg-dark);
+  --fg-segment-dynamic: light-dark(var(--fg-segment), var(--fg-segment-dark))
 
   --bg-panel: white;
   --bg-panel-dark: black;
+  --bg-panel-dynamic: light-dark(var(--bg-panel), var(--bg-panel-dark))
 
   --bg-alert: #fcf8e3;
   --bg-alert-dark: hsl(50, 81%, 6%);
-
   --bg-alert-dynamic: light-dark(var(--bg-alert), var(--bg-alert-dark));
 
   --fg-alert: #8a6d3b;
@@ -65,14 +66,15 @@
   --bg-btn-dl-pr: oklch(72% 0.15 75);
   --bg-btn-dl-pr-dark: color-mix(in oklch, var(--bg-btn-dl-pr), black);
   --bg-btn-dl-pr-dynamic: light-dark(var(--bg-btn-dl-pr), var(--bg-btn-dl-pr-dark));
-  --bg-well: #f5f5f5;
 
+  --bg-well: #f5f5f5;
   --bg-well-dark: hsl(0, 0%, 4%);
   --bg-well-dynamic: light-dark(var(--bg-well), var(--bg-well-dark));
 
   --col-anchor: #337ab7;
   --col-anchor-dark: color-mix(in oklch, var(--col-anchor), white 15%);
   --col-anchor-dynamic: light-dark(var(--col-anchor), var(--col-anchor-dark));
+
   --bg-footer: #222522;
 
   --col-link-shadow: #362a84;
@@ -101,6 +103,48 @@
   --nav-height: 50px;
   --nav-height-neg: calc(-1 * var(--nav-height));
   --animation-time: 150ms;
+}
+
+/* If the browser _doesn't_ support the light-dark() function, set the default value */
+@supports not (background: light-dark(white, black)) {
+  :root {
+    --fg-dynamic: var(--fg);
+
+    --wb-dynamic: white;
+    --bw-dynamic: black;
+
+    --bg-navbar-dynamic: var(--bg-navbar);
+
+    --bg-jumbotron-dynamic: var(--bg-navbar);
+
+    --bg-segment-dynamic: var(--bg-segment);
+
+    --fg-segment-dynamic: var(--fg-segment);
+
+    --bg-panel-dynamic: var(--bg-panel);
+
+    --bg-alert-dynamic: var(--bg-alert);
+
+    --fg-alert-dynamic: var(--fg-alert);
+
+    --bg-btn-dynamic: var(--bg-btn);
+
+    --bg-btn-dl-stable-dynamic: var(--bg-btn-dl-stable);
+
+    --bg-btn-dl-alpha-dynamic: var(--bg-btn-dl-alpha);
+
+    --bg-btn-dl-nightly-dynamic: var(--bg-btn-dl-nightly);
+
+    --bg-btn-dl-pr-dynamic: var(--bg-btn-dl-pr);
+
+    --col-anchor-dynamic: var(--col-anchor);
+
+    --bg-table-lsp-odd-dynamic: var(--bg-table-lsp-odd);
+
+    --bg-lsp-search-dynamic: var(--bg-lsp-search);
+
+    --bg-lsp-actions-dynamic: var(---bg-lsp-actions);
+  }
 }
 
 body {
@@ -792,7 +836,7 @@ a.social:focus {
 .segment {
   padding: 60px 0 70px 0;
   background-color: var(--bg-segment-dynamic);
-  color: var(--bg-segment-dynamic);
+  color: var(--fg-segment-dynamic);
 }
 
 .segment .page-header {
@@ -920,7 +964,7 @@ a.social:focus {
 /* Get Involved Panels */
 .panel-custom {
   border: 1px #dedede solid;
-  background-color: var(--wb-dynamic);
+  background-color: var(--bg-panel-dynamic);
 }
 
 .panel-custom>.panel-heading {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -12,11 +12,11 @@
   --bw-dynamic: light-dark(black, white);
 
   --bg-navbar-light: #10b146;
-  --bg-navbar-dark: color-mix(in oklch, var(--bg-navbar-light), black 25%);
+  --bg-navbar-dark: color-mix(in hsl, var(--bg-navbar-light), black 25%);
   --bg-navbar: light-dark(var(--bg-navbar-light), var(--bg-navbar-dark));
   --bg-navbar-hov: inherit;
 
-  --bg-jumbotron: light-dark(var(--bg-navbar-light), color-mix(in oklch, var(--bg-navbar-light), black 25%));
+  --bg-jumbotron: light-dark(var(--bg-navbar-light), color-mix(in hsl, var(--bg-navbar-light), black 25%));
 
   --fg-navbar: white;
   --fg-navbar-hov: #f2f2f2;
@@ -40,31 +40,31 @@
   --bg-alert: light-dark(var(--bg-alert-light), var(--bg-alert-dark));
 
   --fg-alert-light: #8a6d3b;
-  --fg-alert-dark: color-mix(in oklch, var(--fg-alert-light), white);
+  --fg-alert-dark: color-mix(in hsl, var(--fg-alert-light), white);
   --fg-alert: light-dark(var(--fg-alert-light), var(--fg-alert-dark));
 
   --fg-code-light: #c7254e;
-  --fg-code-dark: color-mix(in oklch, var(--fg-code-light), white 25%);
+  --fg-code-dark: color-mix(in hsl, var(--fg-code-light), white 25%);
   --fg-code: light-dark(var(--fg-code-light), var(--fg-code-dark));
 
   --bg-btn-light: #fafafa;
   --bg-btn-dark: hsl(0, 0%, 2%);
   --bg-btn: light-dark(var(--bg-btn-light), var(--bg-btn-dark));
 
-  --bg-btn-dl-stable-light: oklch(65% 0.15 152);
-  --bg-btn-dl-stable-dark: color-mix(in oklch, var(--bg-btn-dl-stable-light), black);
+  --bg-btn-dl-stable-light: #32a85f;
+  --bg-btn-dl-stable-dark: color-mix(in hsl, var(--bg-btn-dl-stable-light), black);
   --bg-btn-dl-stable: light-dark(var(--bg-btn-dl-stable-light), var(--bg-btn-dl-stable-dark));
 
-  --bg-btn-dl-alpha-light: oklch(60% 0.15 250);
-  --bg-btn-dl-alpha-dark: color-mix(in oklch, var(--bg-btn-dl-alpha-light), black);
+  --bg-btn-dl-alpha-light: #2784d5;
+  --bg-btn-dl-alpha-dark: color-mix(in hsl, var(--bg-btn-dl-alpha-light), black);
   --bg-btn-dl-alpha: light-dark(var(--bg-btn-dl-alpha-light), var(--bg-btn-dl-alpha-dark));
 
-  --bg-btn-dl-nightly-light: oklch(56% 0.2 290);
-  --bg-btn-dl-nightly-dark: color-mix(in oklch, var(--bg-btn-dl-nightly-light), black);
+  --bg-btn-dl-nightly-light: #7855df;
+  --bg-btn-dl-nightly-dark: color-mix(in hsl, var(--bg-btn-dl-nightly-light), black);
   --bg-btn-dl-nightly: light-dark(var(--bg-btn-dl-nightly-light), var(--bg-btn-dl-nightly-dark));
 
-  --bg-btn-dl-pr-light: oklch(72% 0.15 75);
-  --bg-btn-dl-pr-dark: color-mix(in oklch, var(--bg-btn-dl-pr-light), black);
+  --bg-btn-dl-pr-light: #da950b;
+  --bg-btn-dl-pr-dark: color-mix(in hsl, var(--bg-btn-dl-pr-light), black);
   --bg-btn-dl-pr: light-dark(var(--bg-btn-dl-pr-light), var(--bg-btn-dl-pr-dark));
 
   --bg-well-light: #f5f5f5;
@@ -72,15 +72,15 @@
   --bg-well: light-dark(var(--bg-well-light), var(--bg-well-dark));
 
   --col-anchor-light: #337ab7;
-  --col-anchor-dark: color-mix(in oklch, var(--col-anchor-light), white 15%);
+  --col-anchor-dark: color-mix(in hsl, var(--col-anchor-light), white 15%);
   --col-anchor: light-dark(var(--col-anchor-light), var(--col-anchor-dark));
 
   --bg-footer: #222522;
 
   --col-link-shadow: #362a84;
 
-  --fg-stack: color-mix(in oklch, darkorange, black 15%);
-  --fg-stack-hov: color-mix(in oklch, darkorange, black 25%);
+  --fg-stack: color-mix(in hsl, darkorange, black 15%);
+  --fg-stack-hov: color-mix(in hsl, darkorange, black 25%);
   --fg-social: rgba(255, 255, 255, 0.8);
   --fg-social-hov: white;
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4,18 +4,18 @@
 :root {
   color-scheme: light dark;
 
-  --fg: #333;
+  --fg-light: #333;
   --fg-dark: hsl(0, 0%, 80%);
-  --fg-dynamic: light-dark(var(--fg), var(--fg-dark));
+  --fg: light-dark(var(--fg-light), var(--fg-dark));
 
   --wb-dynamic: light-dark(white, black);
   --bw-dynamic: light-dark(black, white);
 
-  --bg-navbar: #10b146;
-  --bg-navbar-dark: color-mix(in oklch, var(--bg-navbar), black 25%);
-  --bg-navbar-dynamic: light-dark(var(--bg-navbar), var(--bg-navbar-dark));
+  --bg-navbar-light: #10b146;
+  --bg-navbar-dark: color-mix(in oklch, var(--bg-navbar-light), black 25%);
+  --bg-navbar: light-dark(var(--bg-navbar-light), var(--bg-navbar-dark));
 
-  --bg-jumbotron-dynamic: light-dark(var(--bg-navbar), color-mix(in oklch, var(--bg-navbar), black 25%));
+  --bg-jumbotron: light-dark(var(--bg-navbar-light), color-mix(in oklch, var(--bg-navbar-light), black 25%));
 
   --bg-navbar-hov: inherit;
 
@@ -24,56 +24,57 @@
 
   --border-navbar-hov: #373b37;
 
-  --bg-segment: white;
+  --bg-segment-light: white;
   --bg-segment-dark: #262b30;
-  --bg-segment-dynamic: light-dark(var(--bg-segment), var(--bg-segment-dark));
+  --bg-segment: light-dark(var(--bg-segment-light), var(--bg-segment-dark));
 
-  --fg-segment: var(--fg);
+  --fg-segment-light: var(--fg-light);
   --fg-segment-dark: var(--fg-dark);
-  --fg-segment-dynamic: light-dark(var(--fg-segment), var(--fg-segment-dark))
+  --fg-segment-dynamic: light-dark(var(--fg-segment), var(--fg-segment-dark));
 
-  --bg-panel: white;
+  --bg-panel-light: white;
   --bg-panel-dark: black;
-  --bg-panel-dynamic: light-dark(var(--bg-panel), var(--bg-panel-dark))
+  --bg-panel: light-dark(var(--bg-panel), var(--bg-panel-dark));
 
-  --bg-alert: #fcf8e3;
+  --bg-alert-light: #fcf8e3;
   --bg-alert-dark: hsl(50, 81%, 6%);
-  --bg-alert-dynamic: light-dark(var(--bg-alert), var(--bg-alert-dark));
+  --bg-alert: light-dark(var(--bg-alert-light), var(--bg-alert-dark));
 
-  --fg-alert: #8a6d3b;
-  --fg-alert-dark: color-mix(in oklch, var(--fg-alert), white);
-  --fg-alert-dynamic: light-dark(var(--fg-alert), var(--fg-alert-dark));
+  --fg-alert-light: #8a6d3b;
+  --fg-alert-dark: color-mix(in oklch, var(--fg-alert-light), white);
+  --fg-alert: light-dark(var(--fg-alert-light), var(--fg-alert-dark));
 
-  --fg-code: #c7254e;
-  --fg-code-dark: color-mix(in oklch, var(--fg-code), white 25%);
+  --fg-code-light: #c7254e;
+  --fg-code-dark: color-mix(in oklch, var(--fg-code-light), white 25%);
+  --fg-code: light-dark(var(--fg-code-light), var(--fg-code-dark));
 
-  --bg-btn: #fafafa;
+  --bg-btn-light: #fafafa;
   --bg-btn-dark: hsl(0, 0%, 2%);
-  --bg-btn-dynamic: light-dark(var(--bg-btn), var(--bg-btn-dark));
+  --bg-btn: light-dark(var(--bg-btn-light), var(--bg-btn-dark));
 
-  --bg-btn-dl-stable: oklch(65% 0.15 152);
-  --bg-btn-dl-stable-dark: color-mix(in oklch, var(--bg-btn-dl-stable), black);
-  --bg-btn-dl-stable-dynamic: light-dark(var(--bg-btn-dl-stable), var(--bg-btn-dl-stable-dark));
+  --bg-btn-dl-stable-light: oklch(65% 0.15 152);
+  --bg-btn-dl-stable-dark: color-mix(in oklch, var(--bg-btn-dl-stable-light), black);
+  --bg-btn-dl-stable: light-dark(var(--bg-btn-dl-stable-light), var(--bg-btn-dl-stable-dark));
 
-  --bg-btn-dl-alpha: oklch(60% 0.15 250);
-  --bg-btn-dl-alpha-dark: color-mix(in oklch, var(--bg-btn-dl-alpha), black);
-  --bg-btn-dl-alpha-dynamic: light-dark(var(--bg-btn-dl-alpha), var(--bg-btn-dl-alpha-dark));
+  --bg-btn-dl-alpha-light: oklch(60% 0.15 250);
+  --bg-btn-dl-alpha-dark: color-mix(in oklch, var(--bg-btn-dl-alpha-light), black);
+  --bg-btn-dl-alpha: light-dark(var(--bg-btn-dl-alpha-light), var(--bg-btn-dl-alpha-dark));
 
-  --bg-btn-dl-nightly: oklch(56% 0.2 290);
-  --bg-btn-dl-nightly-dark: color-mix(in oklch, var(--bg-btn-dl-nightly), black);
-  --bg-btn-dl-nightly-dynamic: light-dark(var(--bg-btn-dl-nightly), var(--bg-btn-dl-nightly-dark));
+  --bg-btn-dl-nightly-light: oklch(56% 0.2 290);
+  --bg-btn-dl-nightly-dark: color-mix(in oklch, var(--bg-btn-dl-nightly-light), black);
+  --bg-btn-dl-nightly: light-dark(var(--bg-btn-dl-nightly-light), var(--bg-btn-dl-nightly-dark));
 
-  --bg-btn-dl-pr: oklch(72% 0.15 75);
-  --bg-btn-dl-pr-dark: color-mix(in oklch, var(--bg-btn-dl-pr), black);
-  --bg-btn-dl-pr-dynamic: light-dark(var(--bg-btn-dl-pr), var(--bg-btn-dl-pr-dark));
+  --bg-btn-dl-pr-light: oklch(72% 0.15 75);
+  --bg-btn-dl-pr-dark: color-mix(in oklch, var(--bg-btn-dl-pr-light), black);
+  --bg-btn-dl-pr: light-dark(var(--bg-btn-dl-pr-light), var(--bg-btn-dl-pr-dark));
 
-  --bg-well: #f5f5f5;
+  --bg-well-light: #f5f5f5;
   --bg-well-dark: hsl(0, 0%, 4%);
-  --bg-well-dynamic: light-dark(var(--bg-well), var(--bg-well-dark));
+  --bg-well: light-dark(var(--bg-well-light), var(--bg-well-dark));
 
-  --col-anchor: #337ab7;
-  --col-anchor-dark: color-mix(in oklch, var(--col-anchor), white 15%);
-  --col-anchor-dynamic: light-dark(var(--col-anchor), var(--col-anchor-dark));
+  --col-anchor-light: #337ab7;
+  --col-anchor-dark: color-mix(in oklch, var(--col-anchor-light), white 15%);
+  --col-anchor: light-dark(var(--col-anchor-light), var(--col-anchor-dark));
 
   --bg-footer: #222522;
 
@@ -84,17 +85,17 @@
   --fg-social: rgba(255, 255, 255, 0.8);
   --fg-social-hov: white;
 
-  --bg-table-lsp-odd: #f9f9f9;
+  --bg-table-lsp-odd-light: #f9f9f9;
   --bg-table-lsp-odd-dark: hsl(0, 0%, 2%);
-  --bg-table-lsp-odd-dynamic: light-dark(var(--bg-table-lsp-odd), var(--bg-table-lsp-odd-dark));
+  --bg-table-lsp-odd: light-dark(var(--bg-table-lsp-odd-light), var(--bg-table-lsp-odd-dark));
 
-  --bg-lsp-search: #eee;
+  --bg-lsp-search-light: #eee;
   --bg-lsp-search-dark: hsl(0, 0, 7%);
-  --bg-lsp-search-dynamic: light-dark(var(--bg-lsp-search), var(--bg-lsp-search-dark));
+  --bg-lsp-search: light-dark(var(--bg-lsp-search-light), var(--bg-lsp-search-dark));
 
-  --bg-lsp-actions: #f8f8f8;
+  --bg-lsp-actions-light: #f8f8f8;
   --bg-lsp-actions-dark: hsl(0, 0%, 3%);
-  --bg-lsp-actions-dynamic: light-dark(var(--bg-lsp-actions), var(--bg-lsp-actions-dark));
+  --bg-lsp-actions: light-dark(var(--bg-lsp-actions-light), var(--bg-lsp-actions-dark));
 
   --col-gray-overlay: rgba(16, 16, 16, 0.75);
   --col-green-overlay: rgba(16, 177, 70, 0.7);
@@ -108,49 +109,49 @@
 /* If the browser _doesn't_ support the light-dark() function, set the default value */
 @supports not (background: light-dark(white, black)) {
   :root {
-    --fg-dynamic: var(--fg);
+    --fg: var(--fg-light);
 
     --wb-dynamic: white;
     --bw-dynamic: black;
 
-    --bg-navbar-dynamic: var(--bg-navbar);
+    --bg-navbar: var(--bg-navbar-light);
 
-    --bg-jumbotron-dynamic: var(--bg-navbar);
+    --bg-jumbotron: var(--bg-navbar-light);
 
-    --bg-segment-dynamic: var(--bg-segment);
+    --bg-segment: var(--bg-segment-light);
 
-    --fg-segment-dynamic: var(--fg-segment);
+    --fg-segment-dynamic: var(--fg-segment-light);
 
-    --bg-panel-dynamic: var(--bg-panel);
+    --bg-panel: var(--bg-panel-light);
 
-    --bg-alert-dynamic: var(--bg-alert);
+    --bg-alert: var(--bg-alert-light);
 
-    --fg-alert-dynamic: var(--fg-alert);
+    --fg-alert: var(--fg-alert-light);
 
-    --bg-btn-dynamic: var(--bg-btn);
+    --bg-btn: var(--bg-btn-light);
 
-    --bg-btn-dl-stable-dynamic: var(--bg-btn-dl-stable);
+    --bg-btn-dl-stable: var(--bg-btn-dl-stable-light);
 
-    --bg-btn-dl-alpha-dynamic: var(--bg-btn-dl-alpha);
+    --bg-btn-dl-alpha: var(--bg-btn-dl-alpha-light);
 
-    --bg-btn-dl-nightly-dynamic: var(--bg-btn-dl-nightly);
+    --bg-btn-dl-nightly: var(--bg-btn-dl-nightly-light);
 
-    --bg-btn-dl-pr-dynamic: var(--bg-btn-dl-pr);
+    --bg-btn-dl-pr: var(--bg-btn-dl-pr-light);
 
-    --col-anchor-dynamic: var(--col-anchor);
+    --col-anchor: var(--col-anchor-light);
 
-    --bg-table-lsp-odd-dynamic: var(--bg-table-lsp-odd);
+    --bg-table-lsp-odd: var(--bg-table-lsp-odd-light);
 
-    --bg-lsp-search-dynamic: var(--bg-lsp-search);
+    --bg-lsp-search: var(--bg-lsp-search-light);
 
-    --bg-lsp-actions-dynamic: var(---bg-lsp-actions);
+    --bg-lsp-actions: var(---bg-lsp-actions);
   }
 }
 
 body {
   padding-top: var(--nav-height);
-  color: var(--fg-dynamic);
-  background-color: var(--bg-segment-dynamic);
+  color: var(--fg);
+  background-color: var(--bg-segment);
   margin: 0;
   min-height: 100%;
   display: flex;
@@ -166,13 +167,13 @@ body {
 }
 
 a {
-  color: var(--col-anchor-dynamic);
+  color: var(--col-anchor);
   font-weight: bold;
   transition: all 0.15s ease-in-out;
 }
 
 .well {
-  background-color: var(--bg-well-dynamic);
+  background-color: var(--bg-well);
 }
 
 .navbar {
@@ -198,7 +199,7 @@ blockquote {
 }
 
 form .input-group .input-group-addon {
-  background-color: var(--bg-lsp-search-dynamic);
+  background-color: var(--bg-lsp-search);
 }
 
 .alert.lsp {
@@ -297,7 +298,7 @@ td.lsp-file-info {
 }
 
 .table-striped>tbody>tr:nth-of-type(odd) {
-  background-color: var(--bg-table-lsp-odd-dynamic);
+  background-color: var(--bg-table-lsp-odd);
 }
 
 .release-notes {
@@ -321,23 +322,23 @@ td.lsp-file-info {
   }
 
   &.btn-dl-stable {
-    background-color: var(--bg-btn-dl-stable-dynamic);
-    border: 1px solid var(--bg-btn-dl-stable);
+    background-color: var(--bg-btn-dl-stable);
+    border: 1px solid var(--bg-btn-dl-stable-light);
   }
 
   &.btn-dl-alpha {
-    background-color: var(--bg-btn-dl-alpha-dynamic);
-    border: 1px solid var(--bg-btn-dl-alpha);
+    background-color: var(--bg-btn-dl-alpha);
+    border: 1px solid var(--bg-btn-dl-alpha-light);
   }
 
   &.btn-dl-nightly {
-    background-color: var(--bg-btn-dl-nightly-dynamic);
-    border: 1px solid var(--bg-btn-dl-nightly);
+    background-color: var(--bg-btn-dl-nightly);
+    border: 1px solid var(--bg-btn-dl-nightly-light);
   }
 
   &.btn-dl-pr {
-    background-color: var(--bg-btn-dl-pr-dynamic);
-    border: 1px solid var(--bg-btn-dl-pr);
+    background-color: var(--bg-btn-dl-pr);
+    border: 1px solid var(--bg-btn-dl-pr-light);
   }
 
   & .small {
@@ -485,18 +486,18 @@ a.btn {
 }
 
 .alert.alert-warning {
-  background-color: var(--bg-alert-dynamic);
-  color: var(--fg-alert-dynamic);
+  background-color: var(--bg-alert);
+  color: var(--fg-alert);
 }
 
 code {
   background-color: var(--wb-dynamic);
-  color: var(--fg-code-dark);
+  color: var(--fg-code);
 }
 
 /* navbar styling */
 .navbar-custom {
-  background-color: var(--bg-navbar-dynamic);
+  background-color: var(--bg-navbar);
   background-image: url("/img/hexagon.png");
   background-position: 0px 0px;
   margin-bottom: 0;
@@ -597,7 +598,7 @@ code {
 }
 
 .navbar-default {
-  background-color: var(--bg-lsp-actions-dynamic);
+  background-color: var(--bg-lsp-actions);
 }
 
 /* inner bottom border on hover over navbar items*/
@@ -723,7 +724,7 @@ div.jumbo {
   overflow: hidden;
   display: flex;
   align-items: center;
-  background: url("/img/screen.png"), url("/img/hexagon.png"), var(--bg-jumbotron-dynamic);
+  background: url("/img/screen.png"), url("/img/hexagon.png"), var(--bg-jumbotron);
   background-position: right bottom, 0px var(--nav-height-neg);
   background-size: auto 80%, auto;
   background-repeat: no-repeat, repeat;
@@ -739,7 +740,7 @@ div.mini {
   overflow: hidden;
   display: flex;
   align-items: center;
-  background: url("/img/hexagon.png"), var(--bg-jumbotron-dynamic);
+  background: url("/img/hexagon.png"), var(--bg-jumbotron);
   background-position: 0px var(--nav-height-neg);
   color: #fff;
   min-height: 15vh;
@@ -751,7 +752,7 @@ div.error {
   overflow: hidden;
   display: flex;
   align-items: center;
-  background: url("/img/hexagon.png"), var(--bg-jumbotron-dynamic);
+  background: url("/img/hexagon.png"), var(--bg-jumbotron);
   background-position: 0px var(--nav-height-neg);
   color: #fff;
   flex: 1;
@@ -782,7 +783,7 @@ div.error a:where(:hover, :focus) {
 
 @media (max-width: 768px) {
   div.jumbo {
-    background: linear-gradient(var(--col-green-overlay), var(--col-green-overlay)), url("/img/screen.png"), var(--bg-jumbotron-dynamic);
+    background: linear-gradient(var(--col-green-overlay), var(--col-green-overlay)), url("/img/screen.png"), var(--bg-jumbotron);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -835,7 +836,7 @@ a.social:focus {
 
 .segment {
   padding: 60px 0 70px 0;
-  background-color: var(--bg-segment-dynamic);
+  background-color: var(--bg-segment);
   color: var(--fg-segment-dynamic);
 }
 
@@ -964,7 +965,7 @@ a.social:focus {
 /* Get Involved Panels */
 .panel-custom {
   border: 1px #dedede solid;
-  background-color: var(--bg-panel-dynamic);
+  background-color: var(--bg-panel);
 }
 
 .panel-custom>.panel-heading {
@@ -987,8 +988,8 @@ a.social:focus {
 .btn-default {
   border: solid 1px;
   border-color: #c9c9c9;
-  background-color: var(--bg-btn-dynamic);
-  color: var(--fg-dynamic);
+  background-color: var(--bg-btn);
+  color: var(--fg);
 }
 
 .btn-file {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -314,48 +314,48 @@ td.lsp-file-info {
   margin: 4px;
   text-align: left;
   padding: 1em 1em 1em 5em;
+}
 
-  &:hover {
-    color: #fff;
-    filter: brightness(1.1);
-  }
+.btn-dl:hover {
+  color: #fff;
+  filter: brightness(1.1);
+}
 
-  &.btn-dl-stable {
-    background-color: var(--bg-btn-dl-stable);
-    border: 1px solid var(--bg-btn-dl-stable-light);
-  }
+.btn-dl.btn-dl-stable {
+  background-color: var(--bg-btn-dl-stable);
+  border: 1px solid var(--bg-btn-dl-stable-light);
+}
 
-  &.btn-dl-alpha {
-    background-color: var(--bg-btn-dl-alpha);
-    border: 1px solid var(--bg-btn-dl-alpha-light);
-  }
+.btn-dl.btn-dl-alpha {
+  background-color: var(--bg-btn-dl-alpha);
+  border: 1px solid var(--bg-btn-dl-alpha-light);
+}
 
-  &.btn-dl-nightly {
-    background-color: var(--bg-btn-dl-nightly);
-    border: 1px solid var(--bg-btn-dl-nightly-light);
-  }
+.btn-dl.btn-dl-nightly {
+  background-color: var(--bg-btn-dl-nightly);
+  border: 1px solid var(--bg-btn-dl-nightly-light);
+}
 
-  &.btn-dl-pr {
-    background-color: var(--bg-btn-dl-pr);
-    border: 1px solid var(--bg-btn-dl-pr-light);
-  }
+.btn-dl.btn-dl-pr {
+  background-color: var(--bg-btn-dl-pr);
+  border: 1px solid var(--bg-btn-dl-pr-light);
+}
 
-  & .small {
-    position: relative;
-    font-size: 0.9em;
-  }
+.btn-dl .small {
+  position: relative;
+  font-size: 0.9em;
+}
 
-  & .big {
-    font-size: 1.2em;
-  }
+.btn-dl .big {
+  font-size: 1.2em;
+}
 
-  & .download-icon {
-    display: block;
-    position: absolute;
-    left: 0.2em;
-    top: 0.3em;
-    opacity: 0.9;
-  }
+.btn-dl .download-icon {
+  display: block;
+  position: absolute;
+  left: 0.2em;
+  top: 0.3em;
+  opacity: 0.9;
 }
 
 /* Prevent cutting off of images on narrow devices*/
@@ -380,12 +380,12 @@ td.lsp-file-info {
 
 div.code-block {
   background-color: transparent;
+}
 
-  pre {
+div.code-block pre {
     background-color: var(--wb-dynamic);
     color: var(--bw-dynamic);
   }
-}
 
 .top {
   float: top;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3,41 +3,78 @@
 ****************/
 :root {
   color-scheme: light dark;
+
   --fg: #333;
   --fg-dark: hsl(0, 0%, 80%);
+  --fg-dynamic: light-dark(var(--fg), var(--fg-dark));
+
+  --wb-dynamic: light-dark(white, black);
+  --bw-dynamic: light-dark(black, white);
+
   --bg-navbar: #10b146;
   --bg-navbar-dark: color-mix(in oklch, var(--bg-navbar), black 25%);
+  --bg-navbar-dynamic: light-dark(var(--bg-navbar), var(--bg-navbar-dark));
+
+  --bg-jumbotron-dynamic: light-dark(var(--bg-navbar), color-mix(in oklch, var(--bg-navbar), black 25%));
+
   --bg-navbar-hov: inherit;
+
   --fg-navbar: white;
   --fg-navbar-hov: #f2f2f2;
+
   --border-navbar-hov: #373b37;
+
   --bg-segment: white;
   --bg-segment-dark: #262b30;
+  --bg-segment-dynamic: light-dark(var(--bg-segment), var(--bg-segment-dark));
+
   --fg-segment: var(--fg);
   --fg-segment-dark: var(--fg-dark);
+
   --bg-panel: white;
   --bg-panel-dark: black;
+
   --bg-alert: #fcf8e3;
   --bg-alert-dark: hsl(50, 81%, 6%);
+
+  --bg-alert-dynamic: light-dark(var(--bg-alert), var(--bg-alert-dark));
+
   --fg-alert: #8a6d3b;
   --fg-alert-dark: color-mix(in oklch, var(--fg-alert), white);
+  --fg-alert-dynamic: light-dark(var(--fg-alert), var(--fg-alert-dark));
+
   --fg-code: #c7254e;
   --fg-code-dark: color-mix(in oklch, var(--fg-code), white 25%);
+
   --bg-btn: #fafafa;
   --bg-btn-dark: hsl(0, 0%, 2%);
+  --bg-btn-dynamic: light-dark(var(--bg-btn), var(--bg-btn-dark));
+
   --bg-btn-dl-stable: oklch(65% 0.15 152);
   --bg-btn-dl-stable-dark: color-mix(in oklch, var(--bg-btn-dl-stable), black);
+  --bg-btn-dl-stable-dynamic: light-dark(var(--bg-btn-dl-stable), var(--bg-btn-dl-stable-dark));
+
   --bg-btn-dl-alpha: oklch(60% 0.15 250);
   --bg-btn-dl-alpha-dark: color-mix(in oklch, var(--bg-btn-dl-alpha), black);
+  --bg-btn-dl-alpha-dynamic: light-dark(var(--bg-btn-dl-alpha), var(--bg-btn-dl-alpha-dark));
+
   --bg-btn-dl-nightly: oklch(56% 0.2 290);
   --bg-btn-dl-nightly-dark: color-mix(in oklch, var(--bg-btn-dl-nightly), black);
+  --bg-btn-dl-nightly-dynamic: light-dark(var(--bg-btn-dl-nightly), var(--bg-btn-dl-nightly-dark));
+
   --bg-btn-dl-pr: oklch(72% 0.15 75);
   --bg-btn-dl-pr-dark: color-mix(in oklch, var(--bg-btn-dl-pr), black);
+  --bg-btn-dl-pr-dynamic: light-dark(var(--bg-btn-dl-pr), var(--bg-btn-dl-pr-dark));
   --bg-well: #f5f5f5;
+
   --bg-well-dark: hsl(0, 0%, 4%);
+  --bg-well-dynamic: light-dark(var(--bg-well), var(--bg-well-dark));
+
   --col-anchor: #337ab7;
   --col-anchor-dark: color-mix(in oklch, var(--col-anchor), white 15%);
+  --col-anchor-dynamic: light-dark(var(--col-anchor), var(--col-anchor-dark));
   --bg-footer: #222522;
+
   --col-link-shadow: #362a84;
 
   --fg-stack: #ed9f00;
@@ -47,10 +84,15 @@
 
   --bg-table-lsp-odd: #f9f9f9;
   --bg-table-lsp-odd-dark: hsl(0, 0%, 2%);
+  --bg-table-lsp-odd-dynamic: light-dark(var(--bg-table-lsp-odd), var(--bg-table-lsp-odd-dark));
+
   --bg-lsp-search: #eee;
   --bg-lsp-search-dark: hsl(0, 0, 7%);
+  --bg-lsp-search-dynamic: light-dark(var(--bg-lsp-search), var(--bg-lsp-search-dark));
+
   --bg-lsp-actions: #f8f8f8;
   --bg-lsp-actions-dark: hsl(0, 0%, 3%);
+  --bg-lsp-actions-dynamic: light-dark(var(--bg-lsp-actions), var(--bg-lsp-actions-dark));
 
   --col-gray-overlay: rgba(16, 16, 16, 0.75);
   --col-green-overlay: rgba(16, 177, 70, 0.7);
@@ -63,8 +105,8 @@
 
 body {
   padding-top: var(--nav-height);
-  color: light-dark(var(--fg), var(--fg-dark));
-  background-color: light-dark(var(--bg-segment), var(--bg-segment-dark));
+  color: var(--fg-dynamic);
+  background-color: var(--bg-segment-dynamic);
   margin: 0;
   min-height: 100%;
   display: flex;
@@ -80,13 +122,13 @@ body {
 }
 
 a {
-  color: light-dark(var(--col-anchor), var(--col-anchor-dark));
+  color: var(--col-anchor-dynamic);
   font-weight: bold;
   transition: all 0.15s ease-in-out;
 }
 
 .well {
-  background-color: light-dark(var(--bg-well), var(--bg-well-dark));
+  background-color: var(--bg-well-dynamic);
 }
 
 .navbar {
@@ -112,7 +154,7 @@ blockquote {
 }
 
 form .input-group .input-group-addon {
-  background-color: light-dark(var(--bg-lsp-search), var(--bg-lsp-search-dark));
+  background-color: var(--bg-lsp-search-dynamic);
 }
 
 .alert.lsp {
@@ -211,7 +253,7 @@ td.lsp-file-info {
 }
 
 .table-striped>tbody>tr:nth-of-type(odd) {
-  background-color: light-dark(var(--bg-table-lsp-odd), var(--bg-table-lsp-odd-dark));
+  background-color: var(--bg-table-lsp-odd-dynamic);
 }
 
 .release-notes {
@@ -235,22 +277,22 @@ td.lsp-file-info {
   }
 
   &.btn-dl-stable {
-    background-color: light-dark(var(--bg-btn-dl-stable), var(--bg-btn-dl-stable-dark));
+    background-color: var(--bg-btn-dl-stable-dynamic);
     border: 1px solid var(--bg-btn-dl-stable);
   }
 
   &.btn-dl-alpha {
-    background-color: light-dark(var(--bg-btn-dl-alpha), var(--bg-btn-dl-alpha-dark));
+    background-color: var(--bg-btn-dl-alpha-dynamic);
     border: 1px solid var(--bg-btn-dl-alpha);
   }
 
   &.btn-dl-nightly {
-    background-color: light-dark(var(--bg-btn-dl-nightly), var(--bg-btn-dl-nightly-dark));
+    background-color: var(--bg-btn-dl-nightly-dynamic);
     border: 1px solid var(--bg-btn-dl-nightly);
   }
 
   &.btn-dl-pr {
-    background-color: light-dark(var(--bg-btn-dl-pr), var(--bg-btn-dl-pr-dark));
+    background-color: var(--bg-btn-dl-pr-dynamic);
     border: 1px solid var(--bg-btn-dl-pr);
   }
 
@@ -288,16 +330,16 @@ td.lsp-file-info {
   display: inline-block;
   text-align: left;
   margin: 0 auto;
-  background-color: light-dark(white, black);
-  color: light-dark(black, white);
+  background-color: var(--wb-dynamic);
+  color: var(--bw-dynamic);
 }
 
 div.code-block {
   background-color: transparent;
 
   pre {
-    background-color: light-dark(white, black);
-    color: light-dark(black, white);
+    background-color: var(--wb-dynamic);
+    color: var(--bw-dynamic);
   }
 }
 
@@ -399,18 +441,18 @@ a.btn {
 }
 
 .alert.alert-warning {
-  background-color: light-dark(var(--bg-alert), var(--bg-alert-dark));
-  color: light-dark(var(--fg-alert), var(--fg-alert-dark));
+  background-color: var(--bg-alert-dynamic);
+  color: var(--fg-alert-dynamic);
 }
 
 code {
-  background-color: light-dark(white, black);
+  background-color: var(--wb-dynamic);
   color: var(--fg-code-dark);
 }
 
 /* navbar styling */
 .navbar-custom {
-  background-color: light-dark(var(--bg-navbar), var(--bg-navbar-dark));
+  background-color: var(--bg-navbar-dynamic);
   background-image: url("/img/hexagon.png");
   background-position: 0px 0px;
   margin-bottom: 0;
@@ -511,7 +553,7 @@ code {
 }
 
 .navbar-default {
-  background-color: light-dark(var(--bg-lsp-actions), var(--bg-lsp-actions-dark));
+  background-color: var(--bg-lsp-actions-dynamic);
 }
 
 /* inner bottom border on hover over navbar items*/
@@ -637,7 +679,7 @@ div.jumbo {
   overflow: hidden;
   display: flex;
   align-items: center;
-  background: url("/img/screen.png"), url("/img/hexagon.png"), light-dark(var(--bg-navbar), color-mix(in oklch, var(--bg-navbar), black 25%));
+  background: url("/img/screen.png"), url("/img/hexagon.png"), var(--bg-jumbotron-dynamic);
   background-position: right bottom, 0px var(--nav-height-neg);
   background-size: auto 80%, auto;
   background-repeat: no-repeat, repeat;
@@ -653,7 +695,7 @@ div.mini {
   overflow: hidden;
   display: flex;
   align-items: center;
-  background: url("/img/hexagon.png"), light-dark(var(--bg-navbar), color-mix(in oklch, var(--bg-navbar), black 25%));
+  background: url("/img/hexagon.png"), var(--bg-jumbotron-dynamic);
   background-position: 0px var(--nav-height-neg);
   color: #fff;
   min-height: 15vh;
@@ -665,7 +707,7 @@ div.error {
   overflow: hidden;
   display: flex;
   align-items: center;
-  background: url("/img/hexagon.png"), light-dark(var(--bg-navbar), color-mix(in oklch, var(--bg-navbar), black 25%));
+  background: url("/img/hexagon.png"), var(--bg-jumbotron-dynamic);
   background-position: 0px var(--nav-height-neg);
   color: #fff;
   flex: 1;
@@ -696,7 +738,7 @@ div.error a:where(:hover, :focus) {
 
 @media (max-width: 768px) {
   div.jumbo {
-    background: linear-gradient(var(--col-green-overlay), var(--col-green-overlay)), url("/img/screen.png"), light-dark(var(--bg-navbar), color-mix(in oklch, var(--bg-navbar), black 25%));
+    background: linear-gradient(var(--col-green-overlay), var(--col-green-overlay)), url("/img/screen.png"), var(--bg-jumbotron-dynamic);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -749,8 +791,8 @@ a.social:focus {
 
 .segment {
   padding: 60px 0 70px 0;
-  background-color: light-dark(var(--bg-segment), var(--bg-segment-dark));
-  color: light-dark(var(--fg-segment), var(--fg-segment-dark));
+  background-color: var(--bg-segment-dynamic);
+  color: var(--bg-segment-dynamic);
 }
 
 .segment .page-header {
@@ -878,7 +920,7 @@ a.social:focus {
 /* Get Involved Panels */
 .panel-custom {
   border: 1px #dedede solid;
-  background-color: light-dark(#fff, #000);
+  background-color: var(--wb-dynamic);
 }
 
 .panel-custom>.panel-heading {
@@ -890,7 +932,7 @@ a.social:focus {
 }
 
 .form-control {
-  background-color: light-dark(white, black);
+  background-color: var(--wb-dynamic);
 }
 
 #lspnav,
@@ -901,8 +943,8 @@ a.social:focus {
 .btn-default {
   border: solid 1px;
   border-color: #c9c9c9;
-  background-color: light-dark(var(--bg-btn), var(--bg-btn-dark));
-  color: light-dark(var(--fg), var(--fg-dark));
+  background-color: var(--bg-btn-dynamic);
+  color: var(--fg-dynamic);
 }
 
 .btn-file {
@@ -986,7 +1028,7 @@ ul.nav-center li {
   border-radius: 0 0;
   border-style: none;
   border-bottom: 2px solid rgba(0, 0, 0, 0);
-  background-color: light-dark(white, black);
+  background-color: var(--wb-dynamic);
 }
 
 .nav-tabs>li>a:where(:hover, :focus) {


### PR DESCRIPTION
This PR intends to close #411 by adding a new set of overridable variables able to be set using CSS `@supports` queries, ensuring the browser sets the proper styling if it can indeed use the function