### PR TITLE
Implement theme toggle

### DIFF
--- a/src/TopNav.php
+++ b/src/TopNav.php
@@ -2,21 +2,29 @@
 namespace App;
 
 use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum TopNavItemType {
+	case Link;
+	case Dropdown;
+	case ThemeToggle;
+}
+
 class TopNav
 {
 	public function __construct(TranslatorInterface $tr)
 	{
 		$this->navbar = [
-			[$tr->trans('News'), '/news'],
-			[$tr->trans('Download'), '/download'],
-			[$tr->trans('Get Involved'), '/get-involved'],
-			[[$tr->trans('Documentation'), $tr->trans('Docs')], '/documentation'],
-			[$tr->trans('Forum'), '/forum'],
-			[[$tr->trans('Sharing Platform'), $tr->trans('Share')], '/lsp'],
+			[$tr->trans('News'), '/news', TopNavItemType::Link],
+			[$tr->trans('Download'), '/download', TopNavItemType::Link],
+			[$tr->trans('Get Involved'), '/get-involved', TopNavItemType::Link],
+			[[$tr->trans('Documentation'), $tr->trans('Docs')], '/documentation', TopNavItemType::Link],
+			[$tr->trans('Forum'), '/forum', TopNavItemType::Link],
+			[[$tr->trans('Sharing Platform'), $tr->trans('Share')], '/lsp', TopNavItemType::Link],
 			[$tr->trans('More'), null, [
 				['fa-eye', $tr->trans('Showcase'), '/showcase'],
 				['fa-trophy', $tr->trans('Competitions'), '/competitions'],
-				['fa-tags', $tr->trans('Branding'), '/branding']]],
+				['fa-tags', $tr->trans('Branding'), '/branding']], TopNavItemType::Link],
+			[$tr->trans('Theme'), null, TopNavItemType::Link]
 			];
 	}
 

--- a/templates/macros.twig
+++ b/templates/macros.twig
@@ -62,7 +62,7 @@
 			{% set extension = file_name|split('.')|last %}
 			<a target="_blank" class="btn btn-default" href="{{button}}" download>
 				<span class="fas fa-image"></span> {{file_name}} <br><small>({{macros.get_file_description(extension)|trim}})</small>
-			</a>&nbsp; 
+			</a>&nbsp;
 		{% endif %}
 	{% endfor %}
 	<br><br><hr><br><br>
@@ -81,7 +81,7 @@
 		'bmp' : 'Bitmap Format'|trans,
 		'ico' : 'Windows Icon Format'|trans,
 		'icns': 'Apple Icon Format'|trans,
-		} 
+		}
 	%}
 	{{descriptions[extension]|default("Unknown File")}}
 {% endmacro %}
@@ -95,7 +95,7 @@
 	</a></li>
 {% endmacro %}
 
-{% macro create_navbar_menu_item(text, url, children = null, rightAlign = false, active = '') %}
+{% macro create_navbar_menu_item(text, url = null, children = null, rightAlign = false, active = '') %}
 	{% import _self as macros %}
 	{% if children is null %}
 	{# Simple menu item. If $text is an array, $text[0] is the title displayed
@@ -103,6 +103,9 @@
 		{% if text is iterable %}
 			<li class="{{active}} visible-lg"> <a href="{{url}}">{{text[0]}}</a></li>
 			<li class="{{active}} hidden-lg"> <a href="{{url}}">{{text[1]}}</a></li>
+		{# If there is no URL, make a blank list item #}
+		{% elseif url is null %}
+			<li class="{{active}}">{{text}}</li>
 		{% else %}
 			<li class="{{active}}"> <a href="{{url}}">{{text}}</a></li>
 		{% endif %}
@@ -132,14 +135,14 @@
 	{% for item in items %}
 		{% if not item[3] is defined %}
 			{% set active = item[1] == current_uri ? 'active' : '' %}
-			{{macros.create_navbar_menu_item(item[0], item[1], item[2]|default(null), false, active)}}
+			{{macros.create_navbar_menu_item(item[0], item[1]|default(null), item[2]|default(null), false, active)}}
 		{% endif %}
 	{% endfor %}
 	</ul>
 	<ul class="nav navbar-nav navbar-right">
 	{% for item in items %}
 		{% if item[3] is defined %}
-			{{macros.create_navbar_menu_item(item[0], item[1], item[2]|default(null), true)}}
+			{{macros.create_navbar_menu_item(item[0], item[1]|default(null), item[2]|default(null), true)}}
 		{% endif %}
 	{% endfor %}
 {% endmacro %}


### PR DESCRIPTION
This PR intends to close #420 (nice) by implementing a theme toggle in the global site nav. This toggle will be powered by JS to set an arbitrary body class to override the CSS colors, eventually deprecating the `light-dark` logical unit in favor of a super-class.

The preference will be stored in a long-living private cookie, which can be easily cleared by the user by clearing their cookie jar or deleting their browsing history