### PR TITLE
Prevent "My Account" collapsing on resize

### DIFF
--- a/public/js/lsp.js
+++ b/public/js/lsp.js
@@ -2,7 +2,7 @@ $(function () {
     $('[data-toggle=\'tooltip\']').tooltip();
 });
 
-$(window).bind('resize load', function () {
+$(window).bind('load', function () {
     if ($(this).width() < 962) {
         collapse_in('#caret');
     } else {


### PR DESCRIPTION
Should close #424. I am unable to run a local instance of the site due to LSP needing a database to render, but this PR should make it so that resize events don't collapse (close) the My Account collapsible, which is weird anyways (why override user interaction?)