### PR TITLE
Remove incorrect mentions of KXStudio repository

### DIFF
--- a/templates/download/linux.twig
+++ b/templates/download/linux.twig
@@ -59,10 +59,6 @@
 			</p>
 			<p>{% trans %}If this doesn't work for you, run this command in a terminal.{% endtrans %}</p>
 			<div class="code-block"><pre>$ sudo apt-get install lmms</pre></div>
-			<p>{% trans %}If the traditional repositories lag behind on versions, try the <a href="https://kx.studio/Repositories#Ubuntu">KXStudio repository</a>.{% endtrans %}</p>
-			<h3>{% trans %}VST Support{% endtrans %}</h3>
-			<p>{% trans %}If your distribution offers VST support (requires the installation of Wine) it is generally offered in a separate package.  For example, using the <a href="https://kx.studio/Repositories#Ubuntu">KXStudio repository</a>, run this command in a terminal.{% endtrans %}</p>
-			<div class="code-block"><pre>$ sudo apt-get install lmms-vst-full</pre></div>
 		</div>
 
 		<div id="linux-mageia" class="tab-pane">


### PR DESCRIPTION
Resolves LMMS/lmms#8093.

It seems like LMMS hasn't been available through the KXStudio repository for several years, despite us listing it as available from there on our downloads page to this day:

<img width="1153" height="177" alt="Image" src="https://github.com/user-attachments/assets/746dcadb-52a3-4184-9ba2-dc307a4d1098" />

KXStudio is aware of this as well: https://github.com/KXStudio/Repository/issues/204, https://github.com/KXStudio/Repository/issues/212

This PR removes the recommendation to use the KXStudio repository, including the outdated instructions for VST support on Debian & Ubuntu (see https://github.com/LMMS/lmms/issues/6243, [debian bug #998387](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=998387))

This PR does not currently remove the corresponding translations. Do I need to do that manually, or is there an automated process to prune unused translation units?