### PR TITLE
Prerender static pages in post_deploy hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ composer.phar
 /public/index.html
 /public/*/index.html
 !/public/documentation/index.html
+/public/translations/
 
 ###> symfony/framework-bundle ###
 /.env.local

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /vendor/
 composer.phar
 /**/*.mo
+/public/index.html
+/public/*/index.html
+!/public/documentation/index.html
 
 ###> symfony/framework-bundle ###
 /.env.local

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -30,11 +30,11 @@ download:
    controller: App\Controller\DownloadController::page
 
 download_pr:
-   path: /download/pull-request/{id}
+   path: /download-pull-request/{id}
    controller: App\Controller\DownloadController::pull_request
 
 download_artifact:
-   path: /download/artifact/{id}
+   path: /download-artifact/{id}
    controller: App\Controller\DownloadController::artifact
 
 news:

--- a/hooks/post_deploy
+++ b/hooks/post_deploy
@@ -6,6 +6,7 @@ export APP_DEBUG=0
 composer dump-env prod
 php bin/console cache:clear
 php bin/console cache:warmup
+php bin/console app:prerender
 mkdir -p var/cache/lsp/
 pushd "$(dirname $0)/../public"
 

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>LMMS user manual</title>
+<meta http-equiv="refresh" content="0; url=https://docs.lmms.io/user-manual/" />
+If not redirected automatically: <a href="https://docs.lmms.io/user-manual/'">User manual</a>
+<!-- TODO Redirect at web server level -->

--- a/public/js/translation.js
+++ b/public/js/translation.js
@@ -1,0 +1,30 @@
+function textNodesUnder(element) {
+	const children = [];
+	const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+	while (walker.nextNode()) {
+		children.push(walker.currentNode);
+	}
+	return children;
+}
+
+;(async function () {
+	for (const language of navigator.languages) {
+		const response = await fetch(`/translations/messages.${language.replace('-', '_')}.xlf.json`);
+		if (response.status == 200) {
+			const messages = await response.json();
+			for (const text of textNodesUnder(document.body)) {
+				const original = text.textContent.trim();
+				if (messages[original]) {
+					text.textContent = messages[original].string;
+				}
+			}
+			for (const element of document.body.querySelectorAll("p")) {
+				const original = element.innerHTML.trim();
+				if (messages[original]) {
+					element.innerHTML = messages[original].string;
+				}
+			}
+			break;
+		}
+	}
+})();

--- a/src/Command/PrerenderCommand.php
+++ b/src/Command/PrerenderCommand.php
@@ -1,0 +1,56 @@
+<?php
+namespace App\Command;
+
+use App\Controller\DownloadController;
+use App\Controller\NewsController;
+
+use LMMS\Artifacts;
+use LMMS\GraphQl;
+use LMMS\Releases;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+use Twig\Environment;
+
+#[AsCommand(name: 'app:prerender')]
+class PrerenderCommand
+{
+	public function __construct(
+		private Artifacts $artifacts,
+		private GraphQl $graphql,
+		private ParameterBagInterface $parameterBag,
+		private Releases $releases,
+		private Environment $twig
+	)
+	{
+	}
+
+	public function __invoke(): int
+	{
+		$this->write('/', $this->twig->render('home.twig'));
+		$this->write('/download/', $this->twig->render(
+			'download/index.twig',
+			(new DownloadController())->getVars($this->releases, $this->artifacts)
+		));
+		$this->write('/news/', $this->twig->render('news/index.twig', [
+			'news' => (new NewsController())->getHtml($this->graphql)
+		]));
+		$this->write('/get-involved/', $this->twig->render('get-involved.twig'));
+		$this->write('/showcase/', $this->twig->render('showcase.twig'));
+		$this->write('/competitions/', $this->twig->render('competitions.twig'));
+		$this->write('/branding/', $this->twig->render('branding.twig'));
+		$this->write('/wiki/', $this->twig->render('wiki.twig'));
+
+		return Command::SUCCESS;
+	}
+
+	private function write($path, $html) {
+		$path = $this->parameterBag->get('kernel.project_dir') . '/public' . $path;
+		if (!is_dir($path)) {
+			mkdir($path, recursive: true);
+		}
+		file_put_contents($path . '/index.html', $html);
+	}
+}

--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -13,44 +13,50 @@ class DownloadController extends AbstractController
     public function page(Releases $releases, Artifacts $artifacts): Response
     {
         try {
-            $assets = $releases->latestStableAssets();
-            $winstable = array_values(array_filter($assets, self::assetsForPlatform(Os::Windows)));
-            $osxstable = array_values(array_filter($assets, self::assetsForPlatform(Os::MacOS)));
-            $linstable = array_values(array_filter($assets, self::assetsForPlatform(Os::Linux)));
-
-            $assets = $releases->latestUnstableAssets();
-            $winpre = array_values(array_filter($assets, self::assetsForPlatform(Os::Windows)));
-            $osxpre = array_values(array_filter($assets, self::assetsForPlatform(Os::MacOS)));
-            $linpre = array_values(array_filter($assets, self::assetsForPlatform(Os::Linux)));
-
-            if ($winstable && $winpre && ($winpre[0]->getDate() < $winstable[0]->getDate()))
-                $winpre = null;
-            if ($osxstable && $osxpre && ($osxpre[0]->getDate() < $osxstable[0]->getDate()))
-                $osxpre = null;
-            if ($linstable && $linpre && ($linpre[0]->getDate() < $linstable[0]->getDate()))
-                $linpre = null;
-
-            $assets = $artifacts->getForBranch('master');
-            $winnightly = array_values(array_filter($assets, self::assetsForPlatform(Os::Windows)));
-            $osxnightly = array_values(array_filter($assets, self::assetsForPlatform(Os::MacOS)));
-            $linnightly = array_values(array_filter($assets, self::assetsForPlatform(Os::Linux)));
-
-            $vars = [
-                'winstable' => $winstable,
-                'winpre' => $winpre,
-                'winnightly' => $winnightly,
-                'osxstable' => $osxstable,
-                'osxpre' => $osxpre,
-                'osxnightly' => $osxnightly,
-                'linstable' => $linstable,
-                'linpre' => $linpre,
-                'linnightly' => $linnightly
-            ];
-            return $this->render('download/index.twig', $vars);
+            return $this->render('download/index.twig', $this->getVars($releases, $artifacts));
         } catch (\Exception $e) {
             error_log($e);
             return $this->render('download/error.twig');
         }
+    }
+
+    // TODO Move to lib?
+    public function getVars(Releases $releases, Artifacts $artifacts): array
+    {
+        $assets = $releases->latestStableAssets();
+        $winstable = array_values(array_filter($assets, self::assetsForPlatform(Os::Windows)));
+        $osxstable = array_values(array_filter($assets, self::assetsForPlatform(Os::MacOS)));
+        $linstable = array_values(array_filter($assets, self::assetsForPlatform(Os::Linux)));
+
+        $assets = $releases->latestUnstableAssets();
+        $winpre = array_values(array_filter($assets, self::assetsForPlatform(Os::Windows)));
+        $osxpre = array_values(array_filter($assets, self::assetsForPlatform(Os::MacOS)));
+        $linpre = array_values(array_filter($assets, self::assetsForPlatform(Os::Linux)));
+
+        if ($winstable && $winpre && ($winpre[0]->getDate() < $winstable[0]->getDate()))
+            $winpre = null;
+        if ($osxstable && $osxpre && ($osxpre[0]->getDate() < $osxstable[0]->getDate()))
+            $osxpre = null;
+        if ($linstable && $linpre && ($linpre[0]->getDate() < $linstable[0]->getDate()))
+            $linpre = null;
+
+        $assets = $artifacts->getForBranch('master');
+        $winnightly = array_values(array_filter($assets, self::assetsForPlatform(Os::Windows)));
+        $osxnightly = array_values(array_filter($assets, self::assetsForPlatform(Os::MacOS)));
+        $linnightly = array_values(array_filter($assets, self::assetsForPlatform(Os::Linux)));
+
+        $vars = [
+            'winstable' => $winstable,
+            'winpre' => $winpre,
+            'winnightly' => $winnightly,
+            'osxstable' => $osxstable,
+            'osxpre' => $osxpre,
+            'osxnightly' => $osxnightly,
+            'linstable' => $linstable,
+            'linpre' => $linpre,
+            'linnightly' => $linnightly
+        ];
+        return $vars;
     }
 
     public function pull_request(string $id, Artifacts $artifacts): Response

--- a/src/Controller/NewsController.php
+++ b/src/Controller/NewsController.php
@@ -17,7 +17,7 @@ class NewsController extends AbstractController
 		}
 	}
 
-	private function getHtml(GraphQl $graphql): array
+	public function getHtml(GraphQl $graphql): array
 	{
 		$results = $graphql->executeQuery($this->getQuery());
 		$html = array();

--- a/templates/foot.twig
+++ b/templates/foot.twig
@@ -35,3 +35,4 @@
 	<script src="/js/smartNavbar.js"></script>
 	{{ foot|raw }}
 	<script type="text/javascript" src="/js/analytics.js"></script>
+	<script type="text/javascript" src="/js/translation.js"></script>


### PR DESCRIPTION
Re: #417, #423

Introduce an `app:prerender` command that renders home page, Download, News, Get Involved, Showcase, Competitions, Branding and Wiki to static pages in `public/`. Call it from `hooks/post_deploy` - is this how the website gets updated in production? You can also call it in cron.

Major difference: trailing slashes, because it's easiest to get working. Where there was `/download`, now there is `/download/`. The web server should redirect to a trailing slash automatically when it sees a directory.

Change e.g. `/download/artifact/...` to `/download-artifact/...` so that the `/download/` static page doesn't prevent nightly downloads from working. Well, they still don't work while the backend is down due to high load, but I get 403 errors from GitHub API when trying to generate multiple download URLs in a row for static pages, so leaving this as is for now.

Add an http-equiv redirect under `/documentation/`. Not a good way to make a redirect, but better than a 502 error.

Note: I think one will need to change web server config so that the HTML is cached at most for a day.

Would these changes be okay?